### PR TITLE
Return nonblocking mode for subprocess pipe polling

### DIFF
--- a/exec_helpers/_ssh_client_base.py
+++ b/exec_helpers/_ssh_client_base.py
@@ -134,7 +134,10 @@ class _MemorizedSSH(type):
                     logger.debug('Reconnect {}'.format(ssh))
                     ssh.reconnect()
                 return ssh
-            if CPYTHON and sys.getrefcount(cls.__cache[key]) == 2:
+            if (
+                CPYTHON and
+                sys.getrefcount(cls.__cache[key]) == 2
+            ):    # pragma: no cover
                 # If we have only cache reference and temporary getrefcount
                 # reference: close connection before deletion
                 logger.debug('Closing {} as unused'.format(cls.__cache[key]))
@@ -161,7 +164,10 @@ class _MemorizedSSH(type):
         # PY3: cache, ssh, temporary
         # PY4: cache, values mapping, ssh, temporary
         for ssh in mcs.__cache.values():
-            if CPYTHON and sys.getrefcount(ssh) == n_count:
+            if (
+                CPYTHON and
+                sys.getrefcount(ssh) == n_count
+            ):  # pragma: no cover
                 logger.debug('Closing {} as unused'.format(ssh))
                 ssh.close()
         mcs.__cache = {}

--- a/test/test_subprocess_runner.py
+++ b/test/test_subprocess_runner.py
@@ -51,6 +51,9 @@ class FakeFileStream(object):
 
 @mock.patch('exec_helpers.subprocess_runner.logger', autospec=True)
 @mock.patch('select.select', autospec=True)
+@mock.patch(
+    'exec_helpers.subprocess_runner.set_nonblocking_pipe', autospec=True
+)
 @mock.patch('subprocess.Popen', autospec=True, name='subprocess.Popen')
 class TestSubprocessRunner(unittest.TestCase):
     @staticmethod
@@ -100,7 +103,7 @@ class TestSubprocessRunner(unittest.TestCase):
         return ("Command exit code '{code!s}':\n{cmd!s}\n"
                 .format(cmd=result.cmd.rstrip(), code=result.exit_code))
 
-    def test_call(self, popen, select, logger):
+    def test_call(self, popen, _, select, logger):
         popen_obj, exp_result = self.prepare_close(popen)
         select.return_value = [popen_obj.stdout, popen_obj.stderr], [], []
 
@@ -147,7 +150,7 @@ class TestSubprocessRunner(unittest.TestCase):
             mock.call.poll(), popen_obj.mock_calls
         )
 
-    def test_call_verbose(self, popen, select, logger):
+    def test_call_verbose(self, popen, _, select, logger):
         popen_obj, _ = self.prepare_close(popen)
         select.return_value = [popen_obj.stdout, popen_obj.stderr], [], []
 
@@ -175,7 +178,7 @@ class TestSubprocessRunner(unittest.TestCase):
                     msg=self.gen_cmd_result_log_message(result)),
             ])
 
-    def test_context_manager(self, popen, select, logger):
+    def test_context_manager(self, popen, _, select, logger):
         popen_obj, exp_result = self.prepare_close(popen)
         select.return_value = [popen_obj.stdout, popen_obj.stderr], [], []
 
@@ -200,7 +203,7 @@ class TestSubprocessRunner(unittest.TestCase):
     def test_execute_timeout_fail(
         self,
         sleep,
-        popen, select, logger
+        popen, _, select, logger
     ):
         popen_obj, exp_result = self.prepare_close(popen)
         popen_obj.configure_mock(returncode=None)
@@ -227,7 +230,7 @@ class TestSubprocessRunner(unittest.TestCase):
             ),
         ))
 
-    def test_execute_no_stdout(self, popen, select, logger):
+    def test_execute_no_stdout(self, popen, _, select, logger):
         popen_obj, exp_result = self.prepare_close(popen, open_stdout=False)
         select.return_value = [popen_obj.stdout, popen_obj.stderr], [], []
 
@@ -265,7 +268,7 @@ class TestSubprocessRunner(unittest.TestCase):
             mock.call.poll(), popen_obj.mock_calls
         )
 
-    def test_execute_no_stderr(self, popen, select, logger):
+    def test_execute_no_stderr(self, popen, _, select, logger):
         popen_obj, exp_result = self.prepare_close(popen, open_stderr=False)
         select.return_value = [popen_obj.stdout, popen_obj.stderr], [], []
 
@@ -304,7 +307,7 @@ class TestSubprocessRunner(unittest.TestCase):
             mock.call.poll(), popen_obj.mock_calls
         )
 
-    def test_execute_no_stdout_stderr(self, popen, select, logger):
+    def test_execute_no_stdout_stderr(self, popen, _, select, logger):
         popen_obj, exp_result = self.prepare_close(
             popen,
             open_stdout=False,


### PR DESCRIPTION
## What do these changes do?

Return nonblocking mode for subprocess pipe polling
Use windows specific calls on windows to unblock pipe
Checked: linux & Windows 10x64

## Are there changes in behavior for the user?

Real-time logging and return deadlock-proof work

## Related issue number

N/A
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
