### PR TITLE
Default timeout

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,12 +121,14 @@ Main methods are `execute`, `check_call` and `check_stderr` for simple executing
 and executing, checking return code and checking for empty stderr output.
 This methods are almost the same for `SSHCleint` and `Subprocess`, except specific flags.
 
+.. note:: By default ALL methods have timeout 1 hour, infinite waiting can be enabled, but it's special case.
+
 .. code-block:: python
 
     result = helper.execute(
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=1 * 60 * 60,  # type: typing.Optional[int]
         **kwargs
     )
 
@@ -136,7 +138,7 @@ This methods are almost the same for `SSHCleint` and `Subprocess`, except specif
     result = helper.check_call(
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=1 * 60 * 60,  # type: typing.Optional[int]
         error_info=None,  # type: typing.Optional[str]
         expected=None,  # type: typing.Optional[typing.Iterable[int]]
         raise_on_err=True,  # type: bool
@@ -148,7 +150,7 @@ This methods are almost the same for `SSHCleint` and `Subprocess`, except specif
     result = helper.check_stderr(
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=1 * 60 * 60,  # type: typing.Optional[int]
         error_info=None,  # type: typing.Optional[str]
         raise_on_err=True,  # type: bool
     )
@@ -193,7 +195,7 @@ Possible to call commands in parallel on multiple hosts if it's not produce huge
     results = SSHClient.execute_together(
         remotes,  # type: typing.Iterable[SSHClient]
         command,  # type: str
-        timeout=None,  # type: typing.Optional[int]
+        timeout=1 * 60 * 60,  # type: typing.Optional[int]
         expected=None,  # type: typing.Optional[typing.Iterable[int]]
         raise_on_err=True  # type: bool
     )
@@ -211,7 +213,7 @@ For execute through SSH host can be used `execute_through_host` method:
         command,  # type: str
         auth=None,  # type: typing.Optional[SSHAuth]
         target_port=22,  # type: int
-        timeout=None,  # type: typing.Optional[int]
+        timeout=1 * 60 * 60,  # type: typing.Optional[int]
         verbose=False,  # type: bool
         get_pty=False,  # type: bool
     )

--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -79,14 +79,14 @@ API: SSHClient and SSHAuth.
 
         Open context manager
 
-        .. versionchanged:: 1.1.0 - lock on enter
+        .. versionchanged:: 1.1.0 lock on enter
 
     .. py:method:: __exit__(self, exc_type, exc_val, exc_tb)
 
         Close context manager and disconnect
 
-        .. versionchanged:: 1.0.0 - disconnect enforced on close
-        .. versionchanged:: 1.1.0 - release lock on exit
+        .. versionchanged:: 1.0.0 disconnect enforced on close
+        .. versionchanged:: 1.1.0 release lock on exit
 
     .. py:method:: sudo(enforce=None)
 
@@ -109,9 +109,9 @@ API: SSHClient and SSHAuth.
         :type open_stderr: bool
         :rtype: ``typing.Tuple[paramiko.Channel, paramiko.ChannelFile, paramiko.ChannelFile, paramiko.ChannelFile]``
 
-        .. versionchanged:: 1.2.0 - open_stdout and open_stderr flags
+        .. versionchanged:: 1.2.0 open_stdout and open_stderr flags
 
-    .. py:method:: execute(command, verbose=False, timeout=None, **kwargs)
+    .. py:method:: execute(command, verbose=False, timeout=1*60*60, **kwargs)
 
         Execute command and wait for return code.
 
@@ -124,7 +124,9 @@ API: SSHClient and SSHAuth.
         :rtype: ExecResult
         :raises: ExecHelperTimeoutError
 
-    .. py:method:: check_call(command, verbose=False, timeout=None, error_info=None, expected=None, raise_on_err=True, **kwargs)
+        .. versionchanged:: 1.2.0 default timeout 1 hour
+
+    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=None, raise_on_err=True, **kwargs)
 
         Execute command and check for return code.
 
@@ -143,7 +145,9 @@ API: SSHClient and SSHAuth.
         :rtype: ExecResult
         :raises: CalledProcessError
 
-    .. py:method:: check_stderr(command, verbose=False, timeout=None, error_info=None, raise_on_err=True, **kwargs)
+        .. versionchanged:: 1.2.0 default timeout 1 hour
+
+    .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, **kwargs)
 
         Execute command expecting return code 0 and empty STDERR.
 
@@ -161,8 +165,9 @@ API: SSHClient and SSHAuth.
         :raises: CalledProcessError
 
         .. note:: expected return codes can be overridden via kwargs.
+        .. versionchanged:: 1.2.0 default timeout 1 hour
 
-    .. py:method:: execute_through_host(hostname, command, auth=None, target_port=22, verbose=False, timeout=None, get_pty=False, **kwargs)
+    .. py:method:: execute_through_host(hostname, command, auth=None, target_port=22, verbose=False, timeout=1*60*60, get_pty=False, **kwargs)
 
         Execute command on remote host through currently connected host.
 
@@ -183,7 +188,9 @@ API: SSHClient and SSHAuth.
         :rtype: ExecResult
         :raises: ExecHelperTimeoutError
 
-    .. py:classmethod:: execute_together(remotes, command, timeout=None, expected=None, raise_on_err=True, **kwargs)
+        .. versionchanged:: 1.2.0 default timeout 1 hour
+
+    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=None, raise_on_err=True, **kwargs)
 
         Execute command on multiple remotes in async mode.
 
@@ -201,6 +208,8 @@ API: SSHClient and SSHAuth.
         :rtype: typing.Dict[typing.Tuple[str, int], ExecResult]
         :raises: ParallelCallProcessError
         :raises: ParallelCallExceptions
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
 
     .. py:method:: open(path, mode='r')
 

--- a/doc/source/Subprocess.rst
+++ b/doc/source/Subprocess.rst
@@ -16,15 +16,15 @@ API: Subprocess
 
         Open context manager
 
-        .. versionchanged:: 1.1.0 - lock on enter
+        .. versionchanged:: 1.1.0 lock on enter
 
     .. py:method:: __exit__(self, exc_type, exc_val, exc_tb)
 
         Close context manager
 
-        .. versionchanged:: 1.1.0 - release lock on exit
+        .. versionchanged:: 1.1.0 release lock on exit
 
-    .. py:method:: execute(command, verbose=False, timeout=None, **kwargs)
+    .. py:method:: execute(command, verbose=False, timeout=1*60*60, **kwargs)
 
         Execute command and wait for return code.
 
@@ -37,10 +37,13 @@ API: Subprocess
         :rtype: ExecResult
         :raises: ExecHelperTimeoutError
 
-        .. versionchanged:: 1.1.0 - make method
-        .. versionchanged:: 1.2.0 - open_stdout and open_stderr flags
+        .. versionchanged:: 1.1.0 make method
+        .. versionchanged:: 1.2.0
 
-    .. py:method:: check_call(command, verbose=False, timeout=None, error_info=None, expected=None, raise_on_err=True, **kwargs)
+            open_stdout and open_stderr flags
+            default timeout 1 hour
+
+    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=None, raise_on_err=True, **kwargs)
 
         Execute command and check for return code.
 
@@ -59,9 +62,10 @@ API: Subprocess
         :rtype: ExecResult
         :raises: CalledProcessError
 
-        .. versionchanged:: 1.1.0 - make method
+        .. versionchanged:: 1.1.0 make method
+        .. versionchanged:: 1.2.0 default timeout 1 hour
 
-    .. py:method:: check_stderr(command, verbose=False, timeout=None, error_info=None, raise_on_err=True, **kwargs)
+    .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, **kwargs)
 
         Execute command expecting return code 0 and empty STDERR.
 
@@ -80,4 +84,5 @@ API: Subprocess
 
         .. note:: expected return codes can be overridden via kwargs.
 
-        .. versionchanged:: 1.1.0 - make method
+        .. versionchanged:: 1.1.0 make method
+        .. versionchanged:: 1.2.0 default timeout 1 hour

--- a/exec_helpers/_ssh_client_base.py
+++ b/exec_helpers/_ssh_client_base.py
@@ -16,6 +16,8 @@
 
 """SSH client helper based on Paramiko. Base class."""
 
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import base64
@@ -37,11 +39,12 @@ import tenacity
 import threaded
 import six
 
-from exec_helpers import exceptions
+from exec_helpers import constants
 from exec_helpers import exec_result
-from exec_helpers import _log_templates
+from exec_helpers import exceptions
 from exec_helpers import proc_enums
 from exec_helpers import ssh_auth
+from exec_helpers import _log_templates
 
 __all__ = ('SSHClientBase', )
 
@@ -690,7 +693,7 @@ class SSHClientBase(BaseSSHClient):
         self,
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         **kwargs
     ):  # type: (...) -> exec_result.ExecResult
         """Execute command and wait for return code.
@@ -726,7 +729,7 @@ class SSHClientBase(BaseSSHClient):
         self,
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         error_info=None,  # type: typing.Optional[str]
         expected=None,  # type: typing.Optional[typing.Iterable[]]
         raise_on_err=True,  # type: bool
@@ -770,7 +773,7 @@ class SSHClientBase(BaseSSHClient):
         self,
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         error_info=None,  # type: typing.Optional[str]
         raise_on_err=True,  # type: bool
         **kwargs
@@ -816,7 +819,7 @@ class SSHClientBase(BaseSSHClient):
         auth=None,  # type: typing.Optional[ssh_auth.SSHAuth]
         target_port=22,  # type: int
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         get_pty=False,  # type: bool
         **kwargs
     ):  # type: (...) -> exec_result.ExecResult
@@ -880,7 +883,7 @@ class SSHClientBase(BaseSSHClient):
         cls,
         remotes,  # type: typing.Iterable[SSHClientBase]
         command,  # type: str
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         expected=None,  # type: typing.Optional[typing.Iterable[]]
         raise_on_err=True,  # type: bool
         **kwargs

--- a/exec_helpers/_ssh_client_base.py
+++ b/exec_helpers/_ssh_client_base.py
@@ -477,7 +477,7 @@ class SSHClientBase(BaseSSHClient):
     def __enter__(self):
         """Get context manager.
 
-        .. versionchanged:: 1.1.0 - lock on enter
+        .. versionchanged:: 1.1.0 lock on enter
         """
         self.lock.acquire()
         return self
@@ -485,8 +485,8 @@ class SSHClientBase(BaseSSHClient):
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit context manager.
 
-        .. versionchanged:: 1.0.0 - disconnect enforced on close
-        .. versionchanged:: 1.1.0 - release lock on exit
+        .. versionchanged:: 1.0.0 disconnect enforced on close
+        .. versionchanged:: 1.1.0 release lock on exit
         """
         self.close()
         self.lock.release()
@@ -537,7 +537,7 @@ class SSHClientBase(BaseSSHClient):
             typing.Optional[paramiko.ChannelFile],
         ]
 
-        .. versionchanged:: 1.2.0 - open_stdout and open_stderr flags
+        .. versionchanged:: 1.2.0 open_stdout and open_stderr flags
         """
         message = _log_templates.CMD_EXEC.format(cmd=command.rstrip())
         self.logger.debug(message)
@@ -706,6 +706,8 @@ class SSHClientBase(BaseSSHClient):
         :type timeout: typing.Optional[int]
         :rtype: ExecResult
         :raises: ExecHelperTimeoutError
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         (
             chan,  # type: paramiko.channel.Channel
@@ -751,6 +753,8 @@ class SSHClientBase(BaseSSHClient):
         :type raise_on_err: bool
         :rtype: ExecResult
         :raises: CalledProcessError
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         expected = proc_enums.exit_codes_to_enums(expected)
         ret = self.execute(command, verbose, timeout, **kwargs)
@@ -794,6 +798,7 @@ class SSHClientBase(BaseSSHClient):
         :raises: CalledProcessError
 
         .. note:: expected return codes can be overridden via kwargs.
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         ret = self.check_call(
             command, verbose, timeout=timeout,
@@ -841,6 +846,8 @@ class SSHClientBase(BaseSSHClient):
         :type get_pty: bool
         :rtype: ExecResult
         :raises: ExecHelperTimeoutError
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         if auth is None:
             auth = self.auth
@@ -904,6 +911,8 @@ class SSHClientBase(BaseSSHClient):
         :rtype: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
         :raises: ParallelCallProcessError
         :raises: ParallelCallExceptions
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         @threaded.threadpooled
         def get_result(

--- a/exec_helpers/constants.py
+++ b/exec_helpers/constants.py
@@ -1,6 +1,4 @@
 #    Copyright 2018 Alexey Stepanov aka penguinolog.
-
-#    Copyright 2017 Mirantis, Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License"); you may
 #    not use this file except in compliance with the License. You may obtain
@@ -14,26 +12,16 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""Text templates for logging."""
+"""Global constants."""
 
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-CMD_EXEC = "Executing command:\n{cmd!s}\n"
-CMD_RESULT = "Command exit code '{result.exit_code!s}':\n{result.cmd}\n"
-CMD_UNEXPECTED_EXIT_CODE = (
-    "{append}Command '{result.cmd}' returned exit code '{result.exit_code!s}' "
-    "while expected '{expected!s}'"
-)
-CMD_UNEXPECTED_STDERR = (
-    "{append}Command '{result.cmd}' STDERR while not expected\n"
-    "\texit code: '{result.exit_code!s}'"
-)
-CMD_WAIT_ERROR = (
-    "Wait for '{result.cmd}' during {timeout!s}s: no return code!\n"
-    '\tSTDOUT:\n'
-    '{result.stdout_brief}\n'
-    '\tSTDERR"\n'
-    '{result.stderr_brief}'
-)
+
+MINUTE = 60
+HOUR = 60 * MINUTE
+
+
+# Default command timeout
+DEFAULT_TIMEOUT = 1 * HOUR

--- a/exec_helpers/exceptions.py
+++ b/exec_helpers/exceptions.py
@@ -15,6 +15,8 @@
 """Package specific exceptions."""
 
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
 
 import typing
 

--- a/exec_helpers/exec_result.py
+++ b/exec_helpers/exec_result.py
@@ -17,6 +17,7 @@
 """Execution restult."""
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import datetime

--- a/exec_helpers/proc_enums.py
+++ b/exec_helpers/proc_enums.py
@@ -20,6 +20,7 @@ Linux signals, Linux & bash return codes.
 """
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import enum

--- a/exec_helpers/ssh_auth.py
+++ b/exec_helpers/ssh_auth.py
@@ -16,6 +16,8 @@
 
 """SSH client credentials class."""
 
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import copy

--- a/exec_helpers/ssh_client.py
+++ b/exec_helpers/ssh_client.py
@@ -17,6 +17,7 @@
 """SSH client helper based on Paramiko. Extended API helpers."""
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import logging

--- a/exec_helpers/subprocess_runner.py
+++ b/exec_helpers/subprocess_runner.py
@@ -184,7 +184,8 @@ class Subprocess(BaseSingleton):
         :type open_stderr: bool
         :rtype: ExecResult
 
-        .. versionchanged:: 1.2.0 - open_stdout and open_stderr flags
+        .. versionchanged:: 1.2.0 open_stdout and open_stderr flags
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         def poll_streams(
             result,  # type: exec_result.ExecResult
@@ -327,6 +328,8 @@ class Subprocess(BaseSingleton):
         :type timeout: typing.Optional[int]
         :rtype: ExecResult
         :raises: ExecHelperTimeoutError
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         result = self.__exec_command(command=command, timeout=timeout,
                                      verbose=verbose, **kwargs)
@@ -360,6 +363,8 @@ class Subprocess(BaseSingleton):
         :type raise_on_err: bool
         :rtype: ExecResult
         :raises: DevopsCalledProcessError
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         expected = proc_enums.exit_codes_to_enums(expected)
         ret = self.execute(command, verbose, timeout, **kwargs)
@@ -398,6 +403,8 @@ class Subprocess(BaseSingleton):
         :type raise_on_err: bool
         :rtype: ExecResult
         :raises: DevopsCalledProcessError
+
+        .. versionchanged:: 1.2.0 default timeout 1 hour
         """
         ret = self.check_call(
             command, verbose, timeout=timeout,

--- a/exec_helpers/subprocess_runner.py
+++ b/exec_helpers/subprocess_runner.py
@@ -17,6 +17,7 @@
 """Python subprocess.Popen wrapper."""
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import logging
@@ -31,10 +32,11 @@ import typing
 import six
 import threaded
 
-from exec_helpers import exceptions
+from exec_helpers import constants
 from exec_helpers import exec_result
-from exec_helpers import _log_templates
+from exec_helpers import exceptions
 from exec_helpers import proc_enums
+from exec_helpers import _log_templates
 
 logger = logging.getLogger(__name__)
 devnull = open(os.devnull)  # subprocess.DEVNULL is py3.3+
@@ -165,7 +167,7 @@ class Subprocess(BaseSingleton):
         command,  # type: str
         cwd=None,  # type: typing.Optional[str]
         env=None,  # type: typing.Optional[typing.Dict[str, typing.Any]]
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         verbose=False,  # type: bool
         open_stdout=True,  # type: bool
         open_stderr=True,  # type: bool
@@ -313,7 +315,7 @@ class Subprocess(BaseSingleton):
         self,
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         **kwargs
     ):  # type: (...) -> exec_result.ExecResult
         """Execute command and wait for return code.
@@ -340,7 +342,7 @@ class Subprocess(BaseSingleton):
         self,
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         error_info=None,  # type: typing.Optional[str]
         expected=None,  # type: _type_expected
         raise_on_err=True,  # type: bool
@@ -380,7 +382,7 @@ class Subprocess(BaseSingleton):
         self,
         command,  # type: str
         verbose=False,  # type: bool
-        timeout=None,  # type: typing.Optional[int]
+        timeout=constants.DEFAULT_TIMEOUT,  # type: typing.Optional[int]
         error_info=None,  # type: typing.Optional[str]
         raise_on_err=True,  # type: bool
         **kwargs

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from __future__ import unicode_literals
 
 import ast
 import collections
@@ -54,7 +55,11 @@ with open('README.rst',) as f:
 
 def _extension(modpath):
     """Make setuptools.Extension."""
-    return setuptools.Extension(modpath, [modpath.replace('.', '/') + '.py'])
+    source_path = modpath.replace('.', '/') + '.py'
+    return setuptools.Extension(
+        modpath if PY3 else modpath.encode('utf-8'),
+        [source_path if PY3 else source_path.encode('utf-8')]
+    )
 
 
 requires_optimization = [

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@
 
 """Execution helpers for simplified usage of subprocess and ssh."""
 
+from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 import ast
@@ -56,6 +58,7 @@ def _extension(modpath):
 
 
 requires_optimization = [
+    _extension('exec_helpers.constants'),
     _extension('exec_helpers._log_templates'),
     _extension('exec_helpers.exceptions'),
     _extension('exec_helpers.exec_result'),

--- a/test/test_exec_result.py
+++ b/test/test_exec_result.py
@@ -15,6 +15,7 @@
 #    under the License.
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 # pylint: disable=no-self-use

--- a/test/test_ssh_client.py
+++ b/test/test_ssh_client.py
@@ -17,6 +17,7 @@
 #    under the License.
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 # pylint: disable=no-self-use
@@ -32,6 +33,7 @@ import mock
 import paramiko
 
 import exec_helpers
+from exec_helpers import constants
 from exec_helpers import exec_result
 
 
@@ -724,8 +726,7 @@ class TestExecute(unittest.TestCase):
         execute_async.assert_called_once_with(command)
         chan.assert_has_calls((mock.call.status_event.is_set(), ))
 
-    @mock.patch(
-        'exec_helpers.ssh_client.SSHClient.execute_async')
+    @mock.patch('exec_helpers.ssh_client.SSHClient.execute_async')
     def test_execute_together(self, execute_async, client, policy, logger):
         (
             chan, _stdin, _, stderr, stdout
@@ -754,10 +755,10 @@ class TestExecute(unittest.TestCase):
         self.assertEqual(
             sorted(chan.mock_calls),
             sorted((
-                mock.call.status_event.wait(None),
+                mock.call.status_event.wait(constants.DEFAULT_TIMEOUT),
                 mock.call.recv_exit_status(),
                 mock.call.close(),
-                mock.call.status_event.wait(None),
+                mock.call.status_event.wait(constants.DEFAULT_TIMEOUT),
                 mock.call.recv_exit_status(),
                 mock.call.close()
             ))
@@ -776,8 +777,7 @@ class TestExecute(unittest.TestCase):
             exec_helpers.SSHClient.execute_together(
                 remotes=remotes, command=command, expected=[1])
 
-    @mock.patch(
-        'exec_helpers.ssh_client.SSHClient.execute_async')
+    @mock.patch('exec_helpers.ssh_client.SSHClient.execute_async')
     def test_execute_together_exceptions(
         self,
         execute_async,  # type: mock.Mock
@@ -815,8 +815,7 @@ class TestExecute(unittest.TestCase):
         for exception in exc.exceptions.values():
             self.assertIsInstance(exception, RuntimeError)
 
-    @mock.patch(
-        'exec_helpers.ssh_client.SSHClient.execute')
+    @mock.patch('exec_helpers.ssh_client.SSHClient.execute')
     def test_check_call(self, execute, client, policy, logger):
         exit_code = 0
         return_value = exec_result.ExecResult(
@@ -855,8 +854,7 @@ class TestExecute(unittest.TestCase):
         self.assertEqual(exc.stderr, stderr_str)
         execute.assert_called_once_with(command, verbose, None)
 
-    @mock.patch(
-        'exec_helpers.ssh_client.SSHClient.execute')
+    @mock.patch('exec_helpers.ssh_client.SSHClient.execute')
     def test_check_call_expected(self, execute, client, policy, logger):
         exit_code = 0
         return_value = exec_result.ExecResult(
@@ -894,8 +892,7 @@ class TestExecute(unittest.TestCase):
             )
         execute.assert_called_once_with(command, verbose, None)
 
-    @mock.patch(
-        'exec_helpers.ssh_client.SSHClient.check_call')
+    @mock.patch('exec_helpers.ssh_client.SSHClient.check_call')
     def test_check_stderr(self, check_call, client, policy, logger):
         return_value = exec_result.ExecResult(
             cmd=command,

--- a/test/test_ssh_client_init.py
+++ b/test/test_ssh_client_init.py
@@ -17,6 +17,7 @@
 #    under the License.
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 # pylint: disable=no-self-use

--- a/test/test_sshauth.py
+++ b/test/test_sshauth.py
@@ -17,6 +17,7 @@
 #    under the License.
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 # pylint: disable=no-self-use

--- a/test/test_subprocess_runner.py
+++ b/test/test_subprocess_runner.py
@@ -17,6 +17,7 @@
 #    under the License.
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import unicode_literals
 
 import logging

--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,7 @@ pypy3 = install, pypy3,
 [testenv:pep8]
 deps =
     flake8
+    flake8-future-import
 usedevelop = False
 commands = flake8
 
@@ -106,6 +107,28 @@ exclude =
     __init__.py,
     docs
 ignore =
+    # Expected
+    # __future__ import "division" present
+    FI50
+    # __future__ import "absolute_import" present
+    FI51
+    # Setup only:
+    # __future__ import "print_function" present
+    FI53
+    # __future__ import "unicode_literals" present
+    FI54
+
+    # Expected missind (not used or required for not supported versions):
+    # __future__ import "with_statement" missing
+    FI12
+    # __future__ import "print_function" missing
+    FI13
+    # __future__ import "generator_stop" missing
+    FI15
+    # __future__ import "nested_scopes" missing
+    FI16
+    # __future__ import "generators" missing
+    FI17
 show-pep8 = True
 show-source = True
 count = True


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set default timeout to 1 hour.
Also check for future imports and add `from __future__ import division`

## Are there changes in behavior for the user?

Default timeout for command is 1 hour instead of infinite wait.

## Related issue number

Fix #15

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
