### PR TITLE
Fix docstrings ans :raises: constructions.

### DIFF
--- a/doc/source/ExecResult.rst
+++ b/doc/source/ExecResult.rst
@@ -84,13 +84,17 @@ API: ExecResult
 
     .. py:attribute:: stdout_json
 
-        ``typing.Any``
         JSON from stdout.
+
+        :rtype: ``typing.Any``
+        :raises DeserializeValueError: STDOUT can not be deserialized as JSON
 
     .. py:attribute:: stdout_yaml
 
-        ``typing.Any``
         YAML from stdout.
+
+        :rtype: ``typing.Any``
+        :raises DeserializeValueError: STDOUT can not be deserialized as YAML
 
     .. py:method:: read_stdout(src=None, log=None, verbose=False)
 

--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -122,7 +122,7 @@ API: SSHClient and SSHAuth.
         :param timeout: Timeout for command execution.
         :type timeout: ``typing.Optional[int]``
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
 
@@ -143,7 +143,8 @@ API: SSHClient and SSHAuth.
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :rtype: ExecResult
-        :raises: CalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
 
@@ -162,7 +163,8 @@ API: SSHClient and SSHAuth.
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :rtype: ExecResult
-        :raises: CalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code or stderr presents
 
         .. note:: expected return codes can be overridden via kwargs.
         .. versionchanged:: 1.2.0 default timeout 1 hour
@@ -186,7 +188,7 @@ API: SSHClient and SSHAuth.
         :param get_pty: open PTY on target machine
         :type get_pty: ``bool``
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
 
@@ -206,8 +208,8 @@ API: SSHClient and SSHAuth.
         :type raise_on_err: ``bool``
         :return: dictionary {(hostname, port): result}
         :rtype: typing.Dict[typing.Tuple[str, int], ExecResult]
-        :raises: ParallelCallProcessError
-        :raises: ParallelCallExceptions
+        :raises ParallelCallProcessError: Unexpected any code at lest on one target
+        :raises ParallelCallExceptions: At lest one exception raised during execution (including timeout)
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
 
@@ -351,4 +353,4 @@ API: SSHClient and SSHAuth.
         :type port: ``int``
         :param log: Log on generic connection failure
         :type log: ``bool``
-        :raises: paramiko.AuthenticationException
+        :raises paramiko.AuthenticationException: Authentication failed.

--- a/doc/source/Subprocess.rst
+++ b/doc/source/Subprocess.rst
@@ -35,7 +35,7 @@ API: Subprocess
         :param timeout: Timeout for command execution.
         :type timeout: ``typing.Optional[int]``
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0
@@ -60,7 +60,8 @@ API: Subprocess
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :rtype: ExecResult
-        :raises: CalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code
 
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0 default timeout 1 hour
@@ -80,7 +81,8 @@ API: Subprocess
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :rtype: ExecResult
-        :raises: CalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code or stderr presents
 
         .. note:: expected return codes can be overridden via kwargs.
 

--- a/doc/source/exceptions.rst
+++ b/doc/source/exceptions.rst
@@ -10,6 +10,10 @@ API: exceptions
 
     Base class for all exceptions raised inside.
 
+.. py:exception:: DeserializeValueError(ExecHelperError, ValueError)
+
+    Deserialize impossible.
+
 .. py:exception:: ExecHelperTimeoutError(ExecHelperError)
 
     Execution timeout.

--- a/exec_helpers/_ssh_client_base.py
+++ b/exec_helpers/_ssh_client_base.py
@@ -412,7 +412,7 @@ class SSHClientBase(BaseSSHClient):
         """SFTP channel access for inheritance.
 
         :rtype: paramiko.sftp_client.SFTPClient
-        :raises: paramiko.SSHException
+        :raises paramiko.SSHException: SFTP connection failed
         """
         if self.__sftp is not None:
             return self.__sftp
@@ -445,7 +445,7 @@ class SSHClientBase(BaseSSHClient):
     @close.class_method
     def close(cls):  # pylint: disable=no-self-argument
         """Close all memorized SSH and SFTP sessions."""
-        # noinspection PyDeprecation
+        # noinspection PyUnresolvedReferences
         cls.__class__.close_connections()
 
     @classmethod
@@ -589,7 +589,7 @@ class SSHClientBase(BaseSSHClient):
         :type timeout: int
         :type verbose: bool
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
         """
         def poll_streams(
             result,  # type: exec_result.ExecResult
@@ -705,7 +705,7 @@ class SSHClientBase(BaseSSHClient):
         :param timeout: Timeout for command execution.
         :type timeout: typing.Optional[int]
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """
@@ -752,7 +752,8 @@ class SSHClientBase(BaseSSHClient):
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: bool
         :rtype: ExecResult
-        :raises: CalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """
@@ -795,7 +796,8 @@ class SSHClientBase(BaseSSHClient):
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: bool
         :rtype: ExecResult
-        :raises: CalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code or stderr presents
 
         .. note:: expected return codes can be overridden via kwargs.
         .. versionchanged:: 1.2.0 default timeout 1 hour
@@ -845,7 +847,7 @@ class SSHClientBase(BaseSSHClient):
         :param get_pty: open PTY on target machine
         :type get_pty: bool
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """
@@ -909,8 +911,10 @@ class SSHClientBase(BaseSSHClient):
         :type raise_on_err: bool
         :return: dictionary {(hostname, port): result}
         :rtype: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
-        :raises: ParallelCallProcessError
-        :raises: ParallelCallExceptions
+        :raises ParallelCallProcessError:
+            Unexpected any code at lest on one target
+        :raises ParallelCallExceptions:
+            At lest one exception raised during execution (including timeout)
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """

--- a/exec_helpers/exceptions.py
+++ b/exec_helpers/exceptions.py
@@ -41,6 +41,12 @@ class ExecHelperError(Exception):
     __slots__ = ()
 
 
+class DeserializeValueError(ExecHelperError, ValueError):
+    """Deserialize impossible."""
+
+    __slots__ = ()
+
+
 class ExecHelperTimeoutError(ExecHelperError):
     """Execution timeout."""
 

--- a/exec_helpers/exec_result.py
+++ b/exec_helpers/exec_result.py
@@ -14,7 +14,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-"""Execution restult."""
+"""Execution result."""
 
 from __future__ import absolute_import
 from __future__ import division
@@ -322,7 +322,8 @@ class ExecResult(object):
 
         :type fmt: str
         :rtype: object
-        :raises: DevopsError
+        :raises NotImplementedError: fmt deserialization not implemented
+        :raises DeserializeValueError: Not valid source format
         """
         try:
             if fmt == 'json':
@@ -335,7 +336,7 @@ class ExecResult(object):
                 '{{stdout!r}}\n'.format(
                     fmt=fmt))
             logger.exception(self.cmd + tmpl.format(stdout=self.stdout_str))
-            raise exceptions.ExecHelperError(
+            raise exceptions.DeserializeValueError(
                 self.cmd + tmpl.format(stdout=self.stdout_brief)
             )
         msg = '{fmt} deserialize target is not implemented'.format(fmt=fmt)
@@ -408,7 +409,7 @@ class ExecResult(object):
         )
 
     def __eq__(self, other):
-        """Comparsion."""
+        """Comparision."""
         return all(
             (
                 getattr(self, val) == getattr(other, val)
@@ -417,7 +418,7 @@ class ExecResult(object):
         )
 
     def __ne__(self, other):
-        """Comparsion."""
+        """Comparision."""
         return not self.__eq__(other)
 
     def __hash__(self):

--- a/exec_helpers/ssh_auth.py
+++ b/exec_helpers/ssh_auth.py
@@ -159,7 +159,7 @@ class SSHAuth(object):
         :type port: int
         :param log: Log on generic connection failure
         :type log: bool
-        :raises: paramiko.AuthenticationException
+        :raises paramiko.AuthenticationException: Authentication failed.
         """
         kwargs = {
             'username': self.username,

--- a/exec_helpers/subprocess_runner.py
+++ b/exec_helpers/subprocess_runner.py
@@ -39,6 +39,7 @@ from exec_helpers import proc_enums
 from exec_helpers import _log_templates
 
 logger = logging.getLogger(__name__)
+# noinspection PyUnresolvedReferences
 devnull = open(os.devnull)  # subprocess.DEVNULL is py3.3+
 
 _win = sys.platform == "win32"
@@ -50,6 +51,7 @@ if _posix:  # pragma: no cover
     import fcntl  # pylint: disable=import-error
 
 elif _win:  # pragma: no cover
+    # noinspection PyUnresolvedReferences
     import msvcrt  # pylint: disable=import-error
     import ctypes
     from ctypes import wintypes  # pylint: disable=import-error
@@ -105,6 +107,7 @@ def set_nonblocking_pipe(pipe):  # type: (os.pipe) -> None
         fcntl.fcntl(descriptor, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
     elif _win:  # pragma: no cover
+        # noinspection PyPep8Naming
         SetNamedPipeHandleState = windll.kernel32.SetNamedPipeHandleState
         SetNamedPipeHandleState.argtypes = [
             wintypes.HANDLE,
@@ -113,6 +116,7 @@ def set_nonblocking_pipe(pipe):  # type: (os.pipe) -> None
             wintypes.LPDWORD
         ]
         SetNamedPipeHandleState.restype = wintypes.BOOL
+        # noinspection PyPep8Naming
         PIPE_NOWAIT = wintypes.DWORD(0x00000001)
         handle = msvcrt.get_osfhandle(descriptor)
 
@@ -327,7 +331,7 @@ class Subprocess(BaseSingleton):
         :type verbose: bool
         :type timeout: typing.Optional[int]
         :rtype: ExecResult
-        :raises: ExecHelperTimeoutError
+        :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """
@@ -362,7 +366,8 @@ class Subprocess(BaseSingleton):
         :type expected: typing.Optional[typing.Iterable[_type_exit_codes]]
         :type raise_on_err: bool
         :rtype: ExecResult
-        :raises: DevopsCalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """
@@ -402,7 +407,8 @@ class Subprocess(BaseSingleton):
         :type error_info: typing.Optional[str]
         :type raise_on_err: bool
         :rtype: ExecResult
-        :raises: DevopsCalledProcessError
+        :raises ExecHelperTimeoutError: Timeout exceeded
+        :raises CalledProcessError: Unexpected exit code or stderr presents
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix docstrings ans :raises: constructions.
Divorce DeserializeValueError from ExecHelperError

## Are there changes in behavior for the user?

Divorce DeserializeValueError from ExecHelperError

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
