### PR TITLE
Require enum34 directly (previously was indirect)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -269,6 +269,7 @@ setup_args = dict(
     extras_require={
         ':python_version == "2.7"': [
             'futures>=1.0',
+            'enum34>=1.1'
         ],
     },
     install_requires=required,

--- a/tox.ini
+++ b/tox.ini
@@ -135,3 +135,11 @@ commands = python setup.py build_sphinx
 [testenv:bandit]
 deps = bandit
 commands = bandit -r exec_helpers
+
+[testenv:dep-graph]
+envdir = {toxworkdir}/dep-graph
+deps =
+    pipenv
+commands =
+    pipenv install -r {toxinidir}/build_requirements.txt --skip-lock
+    pipenv graph


### PR DESCRIPTION
Still no PEP0508 usage due to FPM is not updated
`dep-graph` tox target for dependencies debug