### PR TITLE
Logger fixes. Fix #37

### DIFF
--- a/exec_helpers/_api.py
+++ b/exec_helpers/_api.py
@@ -33,7 +33,6 @@ from exec_helpers import constants
 from exec_helpers import exceptions
 from exec_helpers import exec_result  # noqa  # pylint: disable=unused-import
 from exec_helpers import proc_enums
-from exec_helpers import _log_templates
 
 _type_exit_codes = typing.Union[int, proc_enums.ExitCodes]
 _type_expected = typing.Optional[typing.Iterable[_type_exit_codes]]

--- a/exec_helpers/_api.py
+++ b/exec_helpers/_api.py
@@ -249,7 +249,7 @@ class ExecHelper(object):
                 verbose=verbose,
                 **kwargs
             )
-            message = _log_templates.CMD_RESULT.format(result=result)
+            message = "Command {result.cmd!r} exit code: {result.exit_code!s}".format(result=result)
             self.logger.log(
                 level=logging.INFO if verbose else logging.DEBUG,
                 msg=message
@@ -292,7 +292,8 @@ class ExecHelper(object):
         ret = self.execute(command, verbose, timeout, **kwargs)
         if ret['exit_code'] not in expected:
             message = (
-                _log_templates.CMD_UNEXPECTED_EXIT_CODE.format(
+                "{append}Command {result.cmd!r} returned exit code "
+                "{result.exit_code!s} while expected {expected!s}".format(
                     append=error_info + '\n' if error_info else '',
                     result=ret,
                     expected=expected
@@ -339,7 +340,8 @@ class ExecHelper(object):
             error_info=error_info, raise_on_err=raise_on_err, **kwargs)
         if ret['stderr']:
             message = (
-                _log_templates.CMD_UNEXPECTED_STDERR.format(
+                "{append}Command {result.cmd!r} STDERR while not expected\n"
+                "\texit code: {result.exit_code!s}".format(
                     append=error_info + '\n' if error_info else '',
                     result=ret,
                 ))

--- a/exec_helpers/_log_templates.py
+++ b/exec_helpers/_log_templates.py
@@ -20,18 +20,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import unicode_literals
 
-CMD_EXEC = "Executing command:\n{cmd!s}\n"
-CMD_RESULT = "Command exit code '{result.exit_code!s}':\n{result.cmd}\n"
-CMD_UNEXPECTED_EXIT_CODE = (
-    "{append}Command '{result.cmd}' returned exit code '{result.exit_code!s}' "
-    "while expected '{expected!s}'"
-)
-CMD_UNEXPECTED_STDERR = (
-    "{append}Command '{result.cmd}' STDERR while not expected\n"
-    "\texit code: '{result.exit_code!s}'"
-)
+CMD_EXEC = "Executing command:\n{cmd!r}\n"
+
 CMD_WAIT_ERROR = (
-    "Wait for '{result.cmd}' during {timeout!s}s: no return code!\n"
+    "Wait for {result.cmd!r} during {timeout!s}s: no return code!\n"
     '\tSTDOUT:\n'
     '{result.stdout_brief}\n'
     '\tSTDERR"\n'

--- a/exec_helpers/ssh_auth.py
+++ b/exec_helpers/ssh_auth.py
@@ -187,9 +187,7 @@ class SSHAuth(object):
                     logger.exception('No password has been set!')
                     raise
                 else:
-                    logger.critical(
-                        'Unexpected PasswordRequiredException, '
-                        'when password is set!')
+                    logger.critical('Unexpected PasswordRequiredException, when password is set!')
                     raise
             except (paramiko.AuthenticationException,
                     paramiko.BadHostKeyException):

--- a/test/test_ssh_client_init.py
+++ b/test/test_ssh_client_init.py
@@ -381,9 +381,10 @@ class TestSSHClientInit(unittest.TestCase):
         _ssh.attach_mock(mock.Mock(return_value=_sftp), 'open_sftp')
 
         with mock.patch(
-            'exec_helpers._ssh_client_base.logger',
+            'logging.getLogger',
             autospec=True
-        ) as ssh_logger:
+        ) as get_logger:
+            ssh_logger = get_logger(exec_helpers.SSHClient.__name__)
 
             ssh = exec_helpers.SSHClient(
                 host=host,
@@ -408,13 +409,13 @@ class TestSSHClientInit(unittest.TestCase):
 
             ssh.close()
 
-        log = ssh_logger.getChild(
-            '{host}:{port}'.format(host=host, port=port)
-        )
-        log.assert_has_calls((
-            mock.call.exception('Could not close ssh connection'),
-            mock.call.exception('Could not close sftp connection'),
-        ))
+            log = ssh_logger.getChild(
+                '{host}:{port}'.format(host=host, port=port)
+            )
+            log.assert_has_calls((
+                mock.call.exception('Could not close ssh connection'),
+                mock.call.exception('Could not close sftp connection'),
+            ))
 
     def test_014_init_reconnect(self, client, policy, logger):
         """Test reconnect
@@ -619,9 +620,10 @@ class TestSSHClientInit(unittest.TestCase):
         client.return_value = _ssh
 
         with mock.patch(
-            'exec_helpers._ssh_client_base.logger',
+            'logging.getLogger',
             autospec=True
-        ) as ssh_logger:
+        ) as get_logger:
+            ssh_logger = get_logger(exec_helpers.SSHClient.__name__)
 
             ssh = exec_helpers.SSHClient(
                 host=host, auth=exec_helpers.SSHAuth(password=password))
@@ -631,14 +633,14 @@ class TestSSHClientInit(unittest.TestCase):
                 # noinspection PyStatementEffect
                 ssh._sftp
                 # pylint: enable=pointless-statement
-        log = ssh_logger.getChild(
-            '{host}:{port}'.format(host=host, port=port)
-        )
-        log.assert_has_calls((
-            mock.call.debug('SFTP is not connected, try to connect...'),
-            mock.call.warning(
-                'SFTP enable failed! SSH only is accessible.'),
-        ))
+            log = ssh_logger.getChild(
+                '{host}:{port}'.format(host=host, port=port)
+            )
+            log.assert_has_calls((
+                mock.call.debug('SFTP is not connected, try to connect...'),
+                mock.call.warning(
+                    'SFTP enable failed! SSH only is accessible.'),
+            ))
 
     def test_022_init_sftp_repair(self, client, policy, logger):
         _sftp = mock.Mock()
@@ -652,9 +654,10 @@ class TestSSHClientInit(unittest.TestCase):
         client.return_value = _ssh
 
         with mock.patch(
-            'exec_helpers._ssh_client_base.logger',
+            'logging.getLogger',
             autospec=True
-        ) as ssh_logger:
+        ) as get_logger:
+            ssh_logger = get_logger(exec_helpers.SSHClient.__name__)
 
             ssh = exec_helpers.SSHClient(
                 host=host, auth=exec_helpers.SSHAuth(password=password)
@@ -670,12 +673,12 @@ class TestSSHClientInit(unittest.TestCase):
 
             sftp = ssh._sftp
             self.assertEqual(sftp, open_sftp())
-        log = ssh_logger.getChild(
-            '{host}:{port}'.format(host=host, port=port)
-        )
-        log.assert_has_calls((
-            mock.call.debug('SFTP is not connected, try to connect...'),
-        ))
+            log = ssh_logger.getChild(
+                '{host}:{port}'.format(host=host, port=port)
+            )
+            log.assert_has_calls((
+                mock.call.debug('SFTP is not connected, try to connect...'),
+            ))
 
     @mock.patch('exec_helpers.exec_result.ExecResult', autospec=True)
     def test_023_init_memorize(

--- a/test/test_sshauth.py
+++ b/test/test_sshauth.py
@@ -36,10 +36,7 @@ import exec_helpers
 
 
 def gen_private_keys(amount=1):
-    keys = []
-    for _ in range(amount):
-        keys.append(paramiko.RSAKey.generate(1024))
-    return keys
+    return [paramiko.RSAKey.generate(1024) for _ in range(amount)]
 
 
 def gen_public_key(private_key=None):

--- a/test/test_subprocess_runner.py
+++ b/test/test_subprocess_runner.py
@@ -32,7 +32,7 @@ import exec_helpers
 from exec_helpers import subprocess_runner
 
 command = 'ls ~\nline 2\nline 3\nline с кирилицей'
-command_log = u"Executing command:\n{!s}\n".format(command.rstrip())
+command_log = u"Executing command:\n{!r}\n".format(command.rstrip())
 stdout_list = [b' \n', b'2\n', b'3\n', b' \n']
 stderr_list = [b' \n', b'0\n', b'1\n', b' \n']
 print_stdin = 'read line; echo "$line"'
@@ -105,8 +105,7 @@ class TestSubprocessRunner(unittest.TestCase):
 
     @staticmethod
     def gen_cmd_result_log_message(result):
-        return ("Command exit code '{code!s}':\n{cmd!s}\n"
-                .format(cmd=result.cmd.rstrip(), code=result.exit_code))
+        return u"Command {result.cmd!r} exit code: {result.exit_code!s}".format(result=result)
 
     def test_001_call(
         self,
@@ -369,7 +368,7 @@ class TestSubprocessRunner(unittest.TestCase):
         cmd = "USE='secret=secret_pass' do task"
         log_mask_re = r"secret\s*=\s*([A-Z-a-z0-9_\-]+)"
         masked_cmd = "USE='secret=<*masked*>' do task"
-        cmd_log = u"Executing command:\n{!s}\n".format(masked_cmd)
+        cmd_log = u"Executing command:\n{!r}\n".format(masked_cmd)
 
         popen_obj, exp_result = self.prepare_close(
             popen,
@@ -424,7 +423,7 @@ class TestSubprocessRunner(unittest.TestCase):
         cmd = "USE='secret=secret_pass' do task"
         log_mask_re = r"secret\s*=\s*([A-Z-a-z0-9_\-]+)"
         masked_cmd = "USE='secret=<*masked*>' do task"
-        cmd_log = u"Executing command:\n{!s}\n".format(masked_cmd)
+        cmd_log = u"Executing command:\n{!r}\n".format(masked_cmd)
 
         popen_obj, exp_result = self.prepare_close(
             popen,


### PR DESCRIPTION
* [x] Use class name as logger prefix
* [x] Use normal repr instead of manual `'{}'` code
* [x] On reconnect/close use client logger instead of formatting to str
* [x] Single used log templates moved to the use place