### PR TITLE
Extend ExecHelperTimeoutError Fix #43

### DIFF
--- a/doc/source/exceptions.rst
+++ b/doc/source/exceptions.rst
@@ -14,13 +14,45 @@ API: exceptions
 
     Deserialize impossible.
 
-.. py:exception:: ExecHelperTimeoutError(ExecHelperError)
-
-    Execution timeout.
-
 .. py:exception:: ExecCalledProcessError(ExecHelperError)
 
     Base class for process call errors.
+
+.. py:exception:: ExecHelperTimeoutError(ExecCalledProcessError)
+
+    Execution timeout.
+
+    .. versionchanged:: 1.3.0 provide full result and timeout inside.
+    .. versionchanged:: 1.3.0 subclass ExecCalledProcessError
+
+    .. py:method:: __init__(self, result, timeout)
+
+        Exception for error on process calls.
+
+        :param result: execution result
+        :type result: exec_result.ExecResult
+        :param timeout: timeout for command
+        :type timeout: typing.Union[int, float]
+
+    .. py:attribute:: timeout
+
+        ``int``
+
+    .. py:attribute:: result
+
+        Execution result
+
+        :rtype: ExecResult
+
+    .. py:attribute:: stdout
+
+        ``typing.Text``
+        stdout string or brief string
+
+    .. py:attribute:: stderr
+
+        ``typing.Text``
+        stdout string or brief string
 
 .. py:exception:: CalledProcessError(ExecCalledProcessError)
 
@@ -60,12 +92,12 @@ API: exceptions
 
     .. py:attribute:: stdout
 
-        ``typing.Any``
+        ``typing.Text``
         stdout string or brief string
 
     .. py:attribute:: stderr
 
-        ``typing.Any``
+        ``typing.Text``
         stdout string or brief string
 
 .. py:exception:: ParallelCallExceptions(ExecCalledProcessError)

--- a/exec_helpers/_ssh_client_base.py
+++ b/exec_helpers/_ssh_client_base.py
@@ -735,7 +735,7 @@ class SSHClientBase(six.with_metaclass(_MemorizedSSH, _api.ExecHelper)):
             timeout=timeout
         )
         self.logger.debug(wait_err_msg)
-        raise exceptions.ExecHelperTimeoutError(wait_err_msg)
+        raise exceptions.ExecHelperTimeoutError(result=result, timeout=timeout)
 
     def execute_through_host(
         self,

--- a/exec_helpers/exceptions.pyi
+++ b/exec_helpers/exceptions.pyi
@@ -7,11 +7,30 @@ class ExecHelperError(Exception):
 class DeserializeValueError(ExecHelperError, ValueError):
     ...
 
-class ExecHelperTimeoutError(ExecHelperError):
-    ...
 
 class ExecCalledProcessError(ExecHelperError):
     ...
+
+
+class ExecHelperTimeoutError(ExecCalledProcessError):
+
+    result: exec_result.ExecResult = ...
+    timeout: int = ...
+
+    def __init__(
+        self,
+        result: exec_result.ExecResult,
+        timeout: typing.Union[int, float],
+    ) -> None: ...
+
+    @property
+    def cmd(self) -> str: ...
+
+    @property
+    def stdout(self) -> typing.Text: ...
+
+    @property
+    def stderr(self) -> typing.Text: ...
 
 
 class CalledProcessError(ExecCalledProcessError):

--- a/exec_helpers/subprocess_runner.py
+++ b/exec_helpers/subprocess_runner.py
@@ -269,7 +269,7 @@ class Subprocess(six.with_metaclass(SingletonMeta, _api.ExecHelper)):
             timeout=timeout
         )
         logger.debug(wait_err_msg)
-        raise exceptions.ExecHelperTimeoutError(wait_err_msg)
+        raise exceptions.ExecHelperTimeoutError(result=result, timeout=timeout)
 
     def execute_async(
         self,

--- a/test/test_ssh_client.py
+++ b/test/test_ssh_client.py
@@ -1028,9 +1028,14 @@ class TestExecute(unittest.TestCase):
 
         logger.reset_mock()
 
-        with self.assertRaises(exec_helpers.ExecHelperTimeoutError):
+        with self.assertRaises(exec_helpers.ExecHelperTimeoutError) as cm:
             # noinspection PyTypeChecker
             ssh.execute(command=command, verbose=False, timeout=0.2)
+
+        self.assertEqual(cm.exception.timeout, 0.2)
+        self.assertEqual(cm.exception.cmd, command)
+        self.assertEqual(cm.exception.stdout, stdout_str)
+        self.assertEqual(cm.exception.stderr, stderr_str)
 
         execute_async.assert_called_once_with(command, verbose=False)
         chan.assert_has_calls((mock.call.status_event.is_set(), ))

--- a/test/test_subprocess_runner.py
+++ b/test/test_subprocess_runner.py
@@ -233,9 +233,14 @@ class TestSubprocessRunner(unittest.TestCase):
 
         # noinspection PyTypeChecker
 
-        with self.assertRaises(exec_helpers.ExecHelperTimeoutError):
+        with self.assertRaises(exec_helpers.ExecHelperTimeoutError) as cm:
             # noinspection PyTypeChecker
             runner.execute(command, timeout=0.2)
+
+        self.assertEqual(cm.exception.timeout, 0.2)
+        self.assertEqual(cm.exception.cmd, command)
+        self.assertEqual(cm.exception.stdout, exp_result.stdout_str)
+        self.assertEqual(cm.exception.stderr, exp_result.stderr_str)
 
         popen.assert_has_calls((
             mock.call(


### PR DESCRIPTION
* Re-subclass `ExecCalledProcessError`
* Provide timeout and result
* Add properties to access cmd, stdout_str and stderr_str

## Related issue number

#43 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
