### PR TITLE
Update requirements and metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ exec-helpers
 .. image:: https://coveralls.io/repos/github/python-useful-helpers/exec-helpers/badge.svg?branch=master
     :target: https://coveralls.io/github/python-useful-helpers/exec-helpers?branch=master
 .. image:: https://readthedocs.org/projects/exec-helpers/badge/?version=latest
-    :target: http://exec-helpers.readthedocs.io/
+    :target: https://exec-helpers.readthedocs.io/
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/exec-helpers.svg
     :target: https://pypi.python.org/pypi/exec-helpers

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ six>=1.10.0  # MIT
 threaded>=1.0  # Apache-2.0
 PyYAML>=3.12  # MIT
 advanced-descriptors>=1.0  # Apache-2.0
-typing >= 3.6 ; python_version < "3.7"
+typing >= 3.6 ; python_version < "3.8"

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,17 +7,6 @@ long_description = file: README.rst
 zip_safe = False
 packages = find:
 
-# While setuptools cannot deal with pre-installed incompatible versions,
-# setting a lower bound is not harmful - it makes error messages cleaner. DO
-# NOT set an upper bound on setuptools, as that will lead to uninstallable
-# situations as progressive releases of projects are done.
-# Blacklist setuptools 34.0.0-34.3.2 due to https://github.com/pypa/setuptools/issues/951
-# Blacklist setuptools 36.2.0 due to https://github.com/pypa/setuptools/issues/1086
-setup_requires =
-    setuptools >= 21.0.0,!=24.0.0,!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,!=36.2.0
-
-python_requires = >=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
-
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,9 @@
 [metadata]
 name = exec-helpers
+project_urls =
+    Bug Tracker = https://github.com/python-useful-helpers/exec-helpers/issues
+    Documentation = https://exec-helpers.readthedocs.io/
 
-long_description = file: README.rst
 
 [options]
 zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -261,12 +261,26 @@ setup_args = dict(
         for name, email in variables['__maintainers__'].items()
     ),
     url=variables['__url__'],
+    project_urls={
+        "Bug Tracker": "https://github.com/python-useful-helpers/exec-helpers/issues",
+        "Documentation": "https://exec-helpers.readthedocs.io/",
+    },
     version=variables['__version__'],
     license=variables['__license__'],
     description=variables['__description__'],
     long_description=long_description,
     classifiers=classifiers,
     keywords=keywords,
+    python_requires='>=2.7.5,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+    # While setuptools cannot deal with pre-installed incompatible versions,
+    # setting a lower bound is not harmful - it makes error messages cleaner. DO
+    # NOT set an upper bound on setuptools, as that will lead to uninstallable
+    # situations as progressive releases of projects are done.
+    # Blacklist setuptools 34.0.0-34.3.2 due to https://github.com/pypa/setuptools/issues/951
+    # Blacklist setuptools 36.2.0 due to https://github.com/pypa/setuptools/issues/1086
+    setup_requires="setuptools >= 21.0.0,!=24.0.0,"
+                   "!=34.0.0,!=34.0.1,!=34.0.2,!=34.0.3,!=34.1.0,!=34.1.1,!=34.2.0,!=34.3.0,!=34.3.1,!=34.3.2,"
+                   "!=36.2.0",
     extras_require={
         ':python_version == "2.7"': [
             'futures>=1.0',

--- a/setup.py
+++ b/setup.py
@@ -261,10 +261,6 @@ setup_args = dict(
         for name, email in variables['__maintainers__'].items()
     ),
     url=variables['__url__'],
-    project_urls={
-        "Bug Tracker": "https://github.com/python-useful-helpers/exec-helpers/issues",
-        "Documentation": "https://exec-helpers.readthedocs.io/",
-    },
     version=variables['__version__'],
     license=variables['__license__'],
     description=variables['__description__'],


### PR DESCRIPTION
typing: python <3.8 (due to still not completed)
setup_requires & python_requires in setup.py due to old setuptools logic
project_urls for packaging