### PR TITLE
Allow to disable printing expected runtime errors in SSHAuth

### DIFF
--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -24,6 +24,8 @@ API: SSHClient and SSHAuth.
         :type private_keys: ``typing.Optional[typing.Iterable[paramiko.RSAKey]]``
         :param auth: credentials for connection
         :type auth: typing.Optional[SSHAuth]
+        :param verbose: show additional error/warning messages
+        :type verbose: bool
 
     .. note:: auth has priority over username/password/private_keys
 

--- a/exec_helpers/_ssh_client_base.pyi
+++ b/exec_helpers/_ssh_client_base.pyi
@@ -17,7 +17,8 @@ class _MemorizedSSH(type):
         username: typing.Optional[str]=...,
         password: typing.Optional[str]=...,
         private_keys: typing.Optional[typing.Iterable[paramiko.RSAKey]]=...,
-        auth: typing.Optional[ssh_auth.SSHAuth]=...
+        auth: typing.Optional[ssh_auth.SSHAuth]=...,
+        verbose: bool=...
     ) -> SSHClientBase: ...
 
     @classmethod
@@ -37,7 +38,8 @@ class SSHClientBase(_api.ExecHelper, metaclass=_MemorizedSSH):
         username: typing.Optional[str]=...,
         password: typing.Optional[str]=...,
         private_keys: typing.Optional[typing.Iterable[paramiko.RSAKey]]=...,
-        auth: typing.Optional[ssh_auth.SSHAuth]=...
+        auth: typing.Optional[ssh_auth.SSHAuth]=...,
+        verbose: bool=...
     ) -> None: ...
 
     @property

--- a/test/test_ssh_client_init.py
+++ b/test/test_ssh_client_init.py
@@ -759,3 +759,21 @@ class TestSSHClientInit(unittest.TestCase):
         exec_helpers.SSHClient(host=host)
         client.assert_called_once()
         policy.assert_called_once()
+
+    @mock.patch('time.sleep', autospec=True)
+    def test_026_init_auth_impossible_key_no_verbose(
+            self, sleep, client, policy, logger):
+        connect = mock.Mock(side_effect=paramiko.AuthenticationException)
+
+        _ssh = mock.Mock()
+        _ssh.attach_mock(connect, 'connect')
+        client.return_value = _ssh
+
+        with self.assertRaises(paramiko.AuthenticationException):
+            exec_helpers.SSHClient(
+                host=host,
+                auth=exec_helpers.SSHAuth(key=gen_private_keys(1).pop()),
+                verbose=False
+            )
+
+        logger.assert_not_called()


### PR DESCRIPTION
When users on a node are not prepared yet, it is expected
to get wrong authorization exception like this:

ssh_client.py:147 -- Connection using stored authentication info failed!
Traceback (most recent call last):
...
BadAuthenticationType: ('Bad authentication type', [u'publickey']) (allowed_types=[u'publickey'])

- new parameter to SSHClient 'verbose' allows to disable printing
  such errors during waiting for ssh access.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
