### PR TITLE
Add stdin to hash and use hash for comparing

### DIFF
--- a/exec_helpers/exec_result.py
+++ b/exec_helpers/exec_result.py
@@ -425,12 +425,7 @@ class ExecResult(object):
 
     def __eq__(self, other):  # type: (typing.Any) -> bool
         """Comparision."""
-        return all(
-            (
-                getattr(self, val) == getattr(other, val)
-                for val in ['cmd', 'stdout', 'stderr', 'exit_code']
-            )
-        )
+        return hash(self) == hash(other)
 
     def __ne__(self, other):  # type: (typing.Any) -> bool
         """Comparision."""
@@ -440,6 +435,6 @@ class ExecResult(object):
         """Hash for usage as dict key and in sets."""
         return hash(
             (
-                self.__class__, self.cmd, self.stdout, self.stderr,
+                self.__class__, self.cmd, self.stdin, self.stdout, self.stderr,
                 self.exit_code
             ))

--- a/test/test_exec_result.py
+++ b/test/test_exec_result.py
@@ -105,6 +105,7 @@ class TestExecResult(unittest.TestCase):
                 (
                     exec_helpers.ExecResult,
                     cmd,
+                    None,
                     (),
                     (),
                     exec_helpers.ExitCodes.EX_INVALID

--- a/test/test_subprocess_runner.py
+++ b/test/test_subprocess_runner.py
@@ -564,7 +564,7 @@ class TestSubprocessRunner(unittest.TestCase):
     ):  # type: (...) -> None
         stdin = bytearray(b'this is a line')
 
-        popen_obj, exp_result = self.prepare_close(popen, cmd=print_stdin, stdout_override=[stdin])
+        popen_obj, exp_result = self.prepare_close(popen, cmd=print_stdin, stdout_override=[bytes(l) for l in stdin])
 
         stdin_mock = mock.Mock()
         popen_obj.attach_mock(stdin_mock, 'stdin')


### PR DESCRIPTION
Validation using object content can cause false-positive and false-negative cases + `AttributeError`, so better to use hash information, which should contain enough information about execution result.