### PR TITLE
Subprocess: increase number of threads and return to blocking pipes.

### DIFF
--- a/exec_helpers/exec_result.py
+++ b/exec_helpers/exec_result.py
@@ -185,10 +185,7 @@ class ExecResult(object):
                 if log:
                     log.log(
                         level=logging.INFO if verbose else logging.DEBUG,
-                        msg=line.decode(
-                            'utf-8',
-                            errors='backslashreplace'
-                        ).rstrip()
+                        msg=line.decode('utf-8', errors='backslashreplace').rstrip()
                     )
         except IOError:
             pass

--- a/exec_helpers/subprocess_runner.pyi
+++ b/exec_helpers/subprocess_runner.pyi
@@ -9,9 +9,6 @@ from exec_helpers import exec_result, api
 logger: logging.Logger
 devnull: typing.IO
 
-_win: bool
-_posix: bool
-
 class SingletonMeta(type):
     _instances: typing.Dict[typing.Type, typing.Any] = ...
     _lock: threading.RLock = ...
@@ -25,12 +22,6 @@ class SingletonMeta(type):
         bases: typing.Iterable[typing.Type],
         **kwargs: typing.Dict
     ) -> collections.OrderedDict: ...
-
-
-def set_nonblocking_pipe(pipe: typing.Any) -> None: ...
-
-def set_blocking_pipe(pipe: typing.Any) -> None: ...
-
 
 class Subprocess(api.ExecHelper, metaclass=SingletonMeta):
     def __init__(self, log_mask_re: typing.Optional[str] = ...) -> None: ...

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     py{27,py}: mock
 
 commands =
+    pip freeze
     py.test --junitxml=unit_result.xml --cov-report html --self-contained-html --html=report.html --cov-config .coveragerc --cov=exec_helpers {posargs:test}
     coverage report --fail-under 97
 
@@ -33,28 +34,28 @@ usedevelop = False
 commands =
     python setup.py bdist_wheel
     pip install exec_helpers --no-index -f dist
-    py.test -vv {posargs:test}
+    py.test -vvv {posargs:test}
 
 [testenv:py35-nocov]
 usedevelop = False
 commands =
     python setup.py bdist_wheel
     pip install exec_helpers --no-index -f dist
-    py.test -vv {posargs:test}
+    py.test -vvv {posargs:test}
 
 [testenv:py36-nocov]
 usedevelop = False
 commands =
     python setup.py bdist_wheel
     pip install exec_helpers --no-index -f dist
-    py.test -vv {posargs:test}
+    py.test -vvv {posargs:test}
 
 [testenv:py37-nocov]
 usedevelop = False
 commands =
     python setup.py bdist_wheel
     pip install exec_helpers --no-index -f dist
-    py.test -vv {posargs:test}
+    py.test -vvv {posargs:test}
 
 [testenv:venv]
 commands = {posargs:}


### PR DESCRIPTION
Found several use-cases, when non-blocking pipes can cause data loose.

In tests not checking mised stdout/stderr because of expected
race condition during log output.

- [x] I think the code is well written
- [x] Unit tests for the changes exist
