### PR TITLE
Allow parallel run of commands

### DIFF
--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -138,11 +138,12 @@ API: SSHClient and SSHAuth.
         :param log_mask_re: regex lookup rule to mask command for logger.
                             all MATCHED groups will be replaced by '<*masked*>'
         :type log_mask_re: typing.Optional[str]
-        :rtype: ``typing.Tuple[paramiko.Channel, paramiko.ChannelFile, typing.Optional[paramiko.ChannelFile], typing.Optional[paramiko.ChannelFile]]``
+        :rtype: SshExecuteAsyncResult
 
         .. versionchanged:: 1.2.0 open_stdout and open_stderr flags
         .. versionchanged:: 1.2.0 stdin data
         .. versionchanged:: 1.2.0 get_pty moved to `**kwargs`
+        .. versionchanged:: 2.1.0 Use typed NamedTuple as result
 
     .. py:method:: execute(command, verbose=False, timeout=1*60*60, **kwargs)
 
@@ -388,3 +389,24 @@ API: SSHClient and SSHAuth.
         :param log: Log on generic connection failure
         :type log: ``bool``
         :raises paramiko.AuthenticationException: Authentication failed.
+
+
+.. py:class:: SshExecuteAsyncResult
+
+    Typed NamedTuple
+
+    .. py:attribute:: interface
+
+        ``paramiko.Channel``
+
+    .. py:attribute:: stdin
+
+        ``paramiko.ChannelFile``
+
+    .. py:attribute:: stderr
+
+        ``typing.Optional[paramiko.ChannelFile]``
+
+    .. py:attribute:: stdout
+
+        ``typing.Optional[paramiko.ChannelFile]``

--- a/doc/source/Subprocess.rst
+++ b/doc/source/Subprocess.rst
@@ -56,9 +56,11 @@ API: Subprocess
         :param log_mask_re: regex lookup rule to mask command for logger.
                             all MATCHED groups will be replaced by '<*masked*>'
         :type log_mask_re: ``typing.Optional[str]``
-        :rtype: ``typing.Tuple[subprocess.Popen, None, typing.Optional[typing.IO], typing.Optional[typing.IO], ]``
+        :rtype: SubprocessExecuteAsyncResult
+        :raises OSError: impossible to process STDIN
 
         .. versionadded:: 1.2.0
+        .. versionchanged:: 2.1.0 Use typed NamedTuple as result
 
     .. py:method:: execute(command, verbose=False, timeout=1*60*60, **kwargs)
 
@@ -124,3 +126,24 @@ API: Subprocess
 
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0 default timeout 1 hour
+
+
+.. py:class:: SubprocessExecuteAsyncResult
+
+    Typed NamedTuple
+
+    .. py:attribute:: interface
+
+        ``subprocess.Popen``
+
+    .. py:attribute:: stdin
+
+        ``typing.Optional[typing.IO]``
+
+    .. py:attribute:: stderr
+
+        ``typing.Optional[typing.IO]``
+
+    .. py:attribute:: stdout
+
+        ``typing.Optional[typing.IO]``

--- a/exec_helpers/__init__.py
+++ b/exec_helpers/__init__.py
@@ -28,8 +28,9 @@ from .exceptions import (
 from .exec_result import ExecResult
 from .api import ExecHelper
 from .ssh_auth import SSHAuth
+from ._ssh_client_base import SshExecuteAsyncResult
 from .ssh_client import SSHClient
-from .subprocess_runner import Subprocess  # nosec  # Expected
+from .subprocess_runner import Subprocess, SubprocessExecuteAsyncResult  # nosec  # Expected
 
 __all__ = (
     'ExecHelperError',
@@ -40,8 +41,10 @@ __all__ = (
     'ExecHelperTimeoutError',
     'ExecHelper',
     'SSHClient',
+    'SshExecuteAsyncResult',
     'SSHAuth',
     'Subprocess',
+    'SubprocessExecuteAsyncResult',
     'ExitCodes',
     'ExecResult',
 )

--- a/test/test_ssh_client.py
+++ b/test/test_ssh_client.py
@@ -761,7 +761,7 @@ class TestExecute(unittest.TestCase):
         is_set = mock.Mock(return_value=True)
         chan.status_event.attach_mock(is_set, 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -807,7 +807,7 @@ class TestExecute(unittest.TestCase):
         is_set = mock.Mock(return_value=True)
         chan.status_event.attach_mock(is_set, 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -852,7 +852,7 @@ class TestExecute(unittest.TestCase):
         ) = self.get_patched_execute_async_retval(open_stdout=False)
         chan.status_event.attach_mock(mock.Mock(return_value=True), 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -896,7 +896,7 @@ class TestExecute(unittest.TestCase):
         ) = self.get_patched_execute_async_retval(open_stderr=False)
         chan.status_event.attach_mock(mock.Mock(return_value=True), 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -943,7 +943,7 @@ class TestExecute(unittest.TestCase):
         )
         chan.status_event.attach_mock(mock.Mock(return_value=True), 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -987,7 +987,7 @@ class TestExecute(unittest.TestCase):
         is_set = mock.Mock(return_value=True)
         chan.status_event.attach_mock(is_set, 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -1022,7 +1022,7 @@ class TestExecute(unittest.TestCase):
         chan.status_event.attach_mock(is_set, 'is_set')
         chan.status_event.attach_mock(mock.Mock(), 'wait')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -1056,7 +1056,7 @@ class TestExecute(unittest.TestCase):
         is_set = mock.Mock(return_value=True)
         chan.status_event.attach_mock(is_set, 'is_set')
 
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         ssh = self.get_ssh()
 
@@ -1098,7 +1098,7 @@ class TestExecute(unittest.TestCase):
         (
             chan, _stdin, _, stderr, stdout
         ) = self.get_patched_execute_async_retval()
-        execute_async.return_value = chan, _stdin, stderr, stdout
+        execute_async.return_value = exec_helpers.SshExecuteAsyncResult(chan, _stdin, stderr, stdout)
 
         host2 = '127.0.0.2'
 


### PR DESCRIPTION
* all execute methods can be started in parallel
  if required - use `lock` attribute

* Change `execute_async` signature and use typed NamedTuple.
  Types are exported for typing purposes only.