### PR TITLE
Move all static analisys before tests: make CI faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,17 +64,6 @@ after_success:
 jobs:
   fast_finish: true
   include:
-  - stage: test
-    <<: *python34
-  - stage: test
-    <<: *python35
-  - stage: test
-    <<: *python36
-  - stage: test
-    <<: *python37
-  - stage: test
-    <<: *pypy3
-
   - <<: *static_analysis
     name: "PyLint"
     install:
@@ -99,15 +88,6 @@ jobs:
     script:
     - mypy --strict exec_helpers
 
-  - <<: *test_cythonized
-    <<: *python34
-  - <<: *test_cythonized
-    <<: *python35
-  - <<: *test_cythonized
-    <<: *python36
-  - <<: *test_cythonized
-    <<: *python37
-
   - <<: *code_style_check
     name: "PEP8"
     install:
@@ -122,6 +102,33 @@ jobs:
     - pip install --upgrade pydocstyle
     script:
     - pydocstyle exec_helpers
+  - <<: *code_style_check
+    name: "Black formatting"
+    install:
+    - *upgrade_python_toolset
+    - pip install --upgrade black
+    script:
+    - black --check exec_helpers
+
+  - stage: test
+    <<: *python34
+  - stage: test
+    <<: *python35
+  - stage: test
+    <<: *python36
+  - stage: test
+    <<: *python37
+  - stage: test
+    <<: *pypy3
+
+  - <<: *test_cythonized
+    <<: *python34
+  - <<: *test_cythonized
+    <<: *python35
+  - <<: *test_cythonized
+    <<: *python36
+  - <<: *test_cythonized
+    <<: *python37
 
   - stage: deploy
     # This prevents job from appearing in test plan unless commit is tagged:

--- a/exec_helpers/_ssh_client_base.py
+++ b/exec_helpers/_ssh_client_base.py
@@ -49,6 +49,7 @@ logging.getLogger("paramiko").setLevel(logging.WARNING)
 logging.getLogger("iso8601").setLevel(logging.WARNING)
 
 
+# noinspection PyTypeHints
 class SshExecuteAsyncResult(api.ExecuteAsyncResult):
     """Override original NamedTuple with proper typing."""
 

--- a/exec_helpers/api.py
+++ b/exec_helpers/api.py
@@ -293,7 +293,7 @@ class ExecHelper(metaclass=abc.ABCMeta):
         """
         expected = proc_enums.exit_codes_to_enums(expected)
         ret = self.execute(command, verbose, timeout, **kwargs)
-        if ret["exit_code"] not in expected:
+        if ret.exit_code not in expected:
             message = (
                 "{append}Command {result.cmd!r} returned exit code "
                 "{result.exit_code!s} while expected {expected!s}".format(
@@ -338,7 +338,7 @@ class ExecHelper(metaclass=abc.ABCMeta):
         ret = self.check_call(
             command, verbose, timeout=timeout, error_info=error_info, raise_on_err=raise_on_err, **kwargs
         )
-        if ret["stderr"]:
+        if ret.stderr:
             message = (
                 "{append}Command {result.cmd!r} STDERR while not expected\n"
                 "\texit code: {result.exit_code!s}".format(append=error_info + "\n" if error_info else "", result=ret)

--- a/exec_helpers/subprocess_runner.py
+++ b/exec_helpers/subprocess_runner.py
@@ -37,6 +37,7 @@ from exec_helpers import _log_templates
 logger = logging.getLogger(__name__)  # type: logging.Logger
 
 
+# noinspection PyTypeHints
 class SubprocessExecuteAsyncResult(api.ExecuteAsyncResult):
     """Override original NamedTuple with proper typing."""
 

--- a/test/test_sshauth.py
+++ b/test/test_sshauth.py
@@ -25,12 +25,11 @@ from __future__ import unicode_literals
 import base64
 import contextlib
 import copy
+import io
 import unittest
 
 import mock
 import paramiko
-# noinspection PyUnresolvedReferences
-from six.moves import cStringIO
 
 import exec_helpers
 
@@ -114,7 +113,7 @@ class TestSSHAuth(unittest.TestCase):
                     int_keys.append(k)
 
         self.assertEqual(auth.username, username)
-        with contextlib.closing(cStringIO()) as tgt:
+        with contextlib.closing(io.StringIO()) as tgt:
             auth.enter_password(tgt)
             self.assertEqual(tgt.getvalue(), '{}\n'.format(password))
         self.assertEqual(

--- a/test/test_subprocess_runner.py
+++ b/test/test_subprocess_runner.py
@@ -26,7 +26,6 @@ import subprocess
 import unittest
 
 import mock
-import six
 
 import exec_helpers
 from exec_helpers import subprocess_runner
@@ -553,7 +552,6 @@ class TestSubprocessRunner(unittest.TestCase):
             mock.call.close()
         ])
 
-    @unittest.skipIf(six.PY2, 'Not implemented exception')
     def test_007_check_stdin_fail_broken_pipe(
         self,
         popen,  # type: mock.MagicMock
@@ -657,7 +655,6 @@ class TestSubprocessRunner(unittest.TestCase):
             runner.execute_async(print_stdin, stdin=stdin)
         popen_obj.kill.assert_called_once()
 
-    @unittest.skipIf(six.PY2, 'Not implemented exception')
     def test_010_check_stdin_fail_close_pipe(
         self,
         popen,  # type: mock.MagicMock


### PR DESCRIPTION
* Remove useless `six` usage in tests
* remove `__getitem__` access to exec_result (legacy code)
* enforce black codestyle validation