### PR TITLE
Rework locks model on exec_result.

### DIFF
--- a/doc/source/ExecResult.rst
+++ b/doc/source/ExecResult.rst
@@ -1,7 +1,7 @@
 .. ExecResult
 
 API: ExecResult
-===========================
+===============
 
 .. py:module:: exec_helpers
 .. py:currentmodule:: exec_helpers
@@ -23,10 +23,18 @@ API: ExecResult
         :param exit_code: Exit code. If integer - try to convert to BASH enum.
         :type exit_code: typing.Union[int, ExitCodes]
 
-    .. py:attribute:: lock
+    .. py:attribute:: stdout_lock
 
         ``threading.RLock``
         Lock object for thread-safe operation.
+        .. versionadded:: 2.2.0
+
+    .. py:attribute:: stderr_lock
+
+        ``threading.RLock``
+        Lock object for thread-safe operation.
+
+        .. versionadded:: 2.2.0
 
     .. py:attribute:: timestamp
 

--- a/exec_helpers/__init__.py
+++ b/exec_helpers/__init__.py
@@ -49,7 +49,7 @@ __all__ = (
     "ExecResult",
 )
 
-__version__ = "2.1.3"
+__version__ = "2.2.0"
 __author__ = "Alexey Stepanov"
 __author_email__ = "penguinolog@gmail.com"
 __maintainers__ = {

--- a/exec_helpers/ssh_client.py
+++ b/exec_helpers/ssh_client.py
@@ -36,7 +36,7 @@ class SSHClient(SSHClientBase):
     @staticmethod
     def _path_esc(path: str) -> str:
         """Escape space character in the path."""
-        return path.replace(" ", "\ ")
+        return path.replace(" ", r"\ ")
 
     def mkdir(self, path: str) -> None:
         """Run 'mkdir -p path' on remote.

--- a/test/test_exec_result.py
+++ b/test/test_exec_result.py
@@ -153,7 +153,7 @@ class TestExecResult(unittest.TestCase):
     @mock.patch("exec_helpers.exec_result.logger", autospec=True)
     def test_wrong_result(self, logger):
         """Test logging exception if stdout if not a correct json"""
-        cmd = "ls -la | awk '{print $1\}'"
+        cmd = r"ls -la | awk '{print $1\}'"
         result = exec_helpers.ExecResult(cmd=cmd)
         with self.assertRaises(exec_helpers.ExecHelperError):
             # noinspection PyStatementEffect

--- a/test/test_ssh_client.py
+++ b/test/test_ssh_client.py
@@ -1249,7 +1249,7 @@ class TestSftp(unittest.TestCase):
         )
         return ssh, _sftp
 
-    def test_exists(self, client, policy, logger):
+    def test_exists(self, client, *args):
         ssh, _sftp = self.prepare_sftp_file_tests(client)
         lstat = mock.Mock()
         _sftp.attach_mock(lstat, "lstat")
@@ -1269,7 +1269,7 @@ class TestSftp(unittest.TestCase):
         self.assertFalse(result)
         lstat.assert_called_once_with(dst)
 
-    def test_stat(self, client, policy, logger):
+    def test_stat(self, client, *args):
         ssh, _sftp = self.prepare_sftp_file_tests(client)
         stat = mock.Mock()
         _sftp.attach_mock(stat, "stat")
@@ -1285,7 +1285,7 @@ class TestSftp(unittest.TestCase):
         self.assertEqual(result.st_uid, 0)
         self.assertEqual(result.st_gid, 0)
 
-    def test_isfile(self, client, policy, logger):
+    def test_isfile(self, client, *args):
         class Attrs(object):
             def __init__(self, mode):
                 self.st_mode = mode
@@ -1318,7 +1318,7 @@ class TestSftp(unittest.TestCase):
         self.assertFalse(result)
         lstat.assert_called_once_with(dst)
 
-    def test_isdir(self, client, policy, logger):
+    def test_isdir(self, client, *args):
         class Attrs(object):
             def __init__(self, mode):
                 self.st_mode = mode
@@ -1352,11 +1352,11 @@ class TestSftp(unittest.TestCase):
 
     @mock.patch("exec_helpers.ssh_client.SSHClient.exists")
     @mock.patch("exec_helpers.ssh_client.SSHClient.execute")
-    def test_mkdir(self, execute, exists, client, policy, logger):
+    def test_mkdir(self, execute, exists, *args):
         exists.side_effect = [False, True]
 
         dst = "~/tst dir"
-        escaped_dst = "~/tst\ dir"
+        escaped_dst = r"~/tst\ dir"
 
         # noinspection PyTypeChecker
         ssh = exec_helpers.SSHClient(
@@ -1379,7 +1379,7 @@ class TestSftp(unittest.TestCase):
         execute.assert_not_called()
 
     @mock.patch("exec_helpers.ssh_client.SSHClient.execute")
-    def test_rm_rf(self, execute, client, policy, logger):
+    def test_rm_rf(self, execute, *args):
         dst = "~/tst"
 
         # noinspection PyTypeChecker
@@ -1392,7 +1392,7 @@ class TestSftp(unittest.TestCase):
         ssh.rm_rf(dst)
         execute.assert_called_once_with("rm -rf {}".format(dst))
 
-    def test_open(self, client, policy, logger):
+    def test_open(self, client, *args):
         ssh, _sftp = self.prepare_sftp_file_tests(client)
         fopen = mock.Mock(return_value=True)
         _sftp.attach_mock(fopen, "open")
@@ -1437,7 +1437,7 @@ class TestSftp(unittest.TestCase):
 
     @mock.patch("exec_helpers.ssh_client.SSHClient.isdir")
     @mock.patch("os.path.isdir", autospec=True)
-    def test_upload_file(self, isdir, remote_isdir, client, policy, logger):
+    def test_upload_file(self, isdir, remote_isdir, client, *args):
         ssh, _sftp = self.prepare_sftp_file_tests(client)
         isdir.return_value = False
         remote_isdir.return_value = False
@@ -1455,7 +1455,7 @@ class TestSftp(unittest.TestCase):
     @mock.patch("os.walk")
     @mock.patch("exec_helpers.ssh_client.SSHClient.isdir")
     @mock.patch("os.path.isdir", autospec=True)
-    def test_upload_dir(self, isdir, remote_isdir, walk, mkdir, exists, client, policy, logger):
+    def test_upload_dir(self, isdir, remote_isdir, walk, mkdir, exists, client, *args):
         ssh, _sftp = self.prepare_sftp_file_tests(client)
         isdir.return_value = True
         remote_isdir.return_value = True


### PR DESCRIPTION
Deprecate `ExecResult().lock` property.
Bump to 2.2.0

Expect last release before work start on asyncio support and split py34