### PR TITLE
Fix Subprocess kwargs

### DIFF
--- a/exec_helpers/__init__.py
+++ b/exec_helpers/__init__.py
@@ -51,7 +51,7 @@ __all__ = (
     "ExecResult",
 )
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 __author__ = "Alexey Stepanov"
 __author_email__ = "penguinolog@gmail.com"
 __maintainers__ = {

--- a/exec_helpers/_subprocess_helpers.py
+++ b/exec_helpers/_subprocess_helpers.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 
 __all__ = ("kill_proc_tree", "subprocess_kw")
 
+import os
 import platform
 
 # pylint: disable=unused-import
@@ -58,4 +59,4 @@ subprocess_kw = {}  # type: typing.Dict[str, typing.Any]
 if "Windows" == platform.system():  # pragma: no cover
     subprocess_kw["creationflags"] = 0x00000200
 else:  # pragma: no cover
-    subprocess_kw["start_new_session"] = True
+    subprocess_kw["preexec_fn"] = os.setsid


### PR DESCRIPTION
start_new_session is an argument in fresh python, old use:
  `preexec_fn = os.setsid`