### PR TITLE
Fix: Race condition on process kill: sometimes FIFO are still open

### DIFF
--- a/exec_helpers/async_api/subprocess_runner.py
+++ b/exec_helpers/async_api/subprocess_runner.py
@@ -134,7 +134,7 @@ class Subprocess(api.ExecHelper, metaclass=metaclasses.SingleLock):
         except asyncio.TimeoutError:
             try:
                 # kill -9 for all subprocesses
-                _subprocess_helpers.kill_proc_tree(async_result.interface.pid, including_parent=False)
+                _subprocess_helpers.kill_proc_tree(async_result.interface.pid)
                 async_result.interface.kill()  # kill -9
             except OSError:
                 # Wait for 1 ms: check close

--- a/test/test_subprocess_special.py
+++ b/test/test_subprocess_special.py
@@ -76,13 +76,13 @@ configs = {
     "no_stdout": dict(),
     "IOError_on_stdout_read": dict(stdout=(b" \n", b"2\n", IOError())),
     "TimeoutError": dict(
-        ec=(timeout_expired_exc,), poll=(None,), stdout=(), expect_exc=exec_helpers.ExecHelperTimeoutError
+        ec=(timeout_expired_exc,), poll=(None, None, None,), stdout=(), expect_exc=exec_helpers.ExecHelperTimeoutError
     ),
     "TimeoutError_closed": dict(
         ec=(timeout_expired_exc, 0), poll=(None, 0), stdout=(b" \n", b"2\n", b"3\n", b" \n"), kill=(OSError(),)
     ),
     "TimeoutError_no_kill": dict(
-        ec=(timeout_expired_exc,), poll=(None, None), stdout=(), kill=(OSError(),), expect_exc=OSError
+        ec=(timeout_expired_exc,), poll=(None, None, None,), stdout=(), kill=(OSError(),), expect_exc=OSError
     ),
     "stdin_closed_PIPE_windows": dict(stdout=(b" \n", b"2\n", b"3\n", b" \n"), stdin="Warning", write=einval_exc),
     "stdin_broken_PIPE": dict(stdout=(b" \n", b"2\n", b"3\n", b" \n"), stdin="Warning", write=epipe_exc),
@@ -153,6 +153,7 @@ def exec_result(run_parameters):
 @pytest.fixture
 def create_subprocess_shell(mocker, run_parameters):
     mocker.patch("psutil.Process")
+    mocker.patch("psutil.wait_procs", return_value=([], []))
 
     def create_mock(
         stdout: typing.Optional[typing.Tuple] = None,


### PR DESCRIPTION
Log critical if readers are still running.
Allow exception on stream close (do not handle) to protect from leak.
Primary use SIGTERM for graceful shutdown, then retry with SIGKILL