### PR TITLE
Move forward: split python 3.5 and actual pythons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,14 @@ install:
 - pip install --upgrade pytest-cov coveralls
 
 _python:
-- &python35
-  name: "Python 3.5"
-  python: 3.5
 - &python36
   name: "Python 3.6"
-  python: 3.6
+  python: "3.6"
 - &python37
   name: "Python 3.7"
-  python: 3.7
+  python: "3.7"
   dist: xenial
   sudo: true
-- &pypy3
-  name: "PyPy3"
-  python: pypy3.5
 
 _helpers:
 - &install_cython pip install --upgrade Cython
@@ -99,25 +93,19 @@ jobs:
 #    - pip install --upgrade pydocstyle
 #    script:
 #    - pydocstyle -v exec_helpers
-#  - <<: *code_style_check
-#    name: "Black formatting"
-#    install:
-#    - *upgrade_python_toolset
-#    - pip install --upgrade black
-#    script:
-#    - black --check exec_helpers
+  - <<: *code_style_check
+    name: "Black formatting"
+    install:
+    - *upgrade_python_toolset
+    - pip install --upgrade black
+    script:
+    - black --check exec_helpers
 
-  - stage: test
-    <<: *python35
   - stage: test
     <<: *python36
   - stage: test
     <<: *python37
-  - stage: test
-    <<: *pypy3
 
-  - <<: *test_cythonized
-    <<: *python35
   - <<: *test_cythonized
     <<: *python36
   - <<: *test_cythonized
@@ -127,16 +115,16 @@ jobs:
     # This prevents job from appearing in test plan unless commit is tagged:
     if: tag IS present
     # Run on pypy to build not cythonized wheel
-    <<: *pypy3
+    <<: *python37
     name: Build universal and cythonized bdist_wheel. Deploy bdist and sdist.
     services:
     - docker
     install:
     - *upgrade_python_toolset
+    - *install_deps
     script:
     - ./tools/run_docker.sh "exec_helpers"
     before_deploy:
-    - pip install -r build_requirements.txt
     - *build_package
     deploy:
     - provider: pypi

--- a/README.rst
+++ b/README.rst
@@ -46,12 +46,10 @@ Pros:
 
 ::
 
-    Python 3.5
     Python 3.6
     Python 3.7
-    PyPy3 3.5+
 
-.. note:: For Python 2.7 and PyPy please use versions 1.x.x. For python 3.4 use versions 2.x.x
+.. note:: Old pythons: For Python 2.7 and PyPy use versions 1.x.x, python 3.4 use versions 2.x.x, python 3.5 and PyPy 3.5 use versions 3.x.x
 
 This package includes:
 
@@ -125,13 +123,13 @@ Base methods
 ------------
 Main methods are `execute`, `check_call` and `check_stderr` for simple executing, executing and checking return code
 and executing, checking return code and checking for empty stderr output.
-This methods are almost the same for `SSHCleint` and `Subprocess`, except specific flags.
+This methods are almost the same for `SSHClient` and `Subprocess`, except specific flags.
 
 .. note:: By default ALL methods have timeout 1 hour, infinite waiting can be enabled, but it's special case.
 
 .. code-block:: python
 
-    result = helper.execute(
+    result: ExecResult = helper.execute(
         command,  # type: str
         verbose=False,  # type: bool
         timeout=1 * 60 * 60,  # type: typing.Union[int, float, None]
@@ -141,7 +139,7 @@ This methods are almost the same for `SSHCleint` and `Subprocess`, except specif
 
 .. code-block:: python
 
-    result = helper.check_call(
+    result: ExecResult = helper.check_call(
         command,  # type: str
         verbose=False,  # type: bool
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
@@ -155,7 +153,7 @@ This methods are almost the same for `SSHCleint` and `Subprocess`, except specif
 
 .. code-block:: python
 
-    result = helper.check_stderr(
+    result: ExecResult = helper.check_stderr(
         command,  # type: str
         verbose=False,  # type: bool
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
@@ -168,7 +166,7 @@ This methods are almost the same for `SSHCleint` and `Subprocess`, except specif
 
 .. code-block:: python
 
-    result = helper(  # Lazy way: instances are callable and uses `execute`.
+    result: ExecResult = helper(  # Lazy way: instances are callable and uses `execute`.
         command,  # type: str
         verbose=False,  # type: bool
         timeout=1 * 60 * 60,  # type: typing.Union[int, float, None]
@@ -185,7 +183,7 @@ All regex matched groups will be replaced by `'<*masked*>'`.
 
 .. code-block:: python
 
-    result = helper.execute(
+    result: ExecResult = helper.execute(
         command="AUTH='top_secret_key'; run command",  # type: str
         verbose=False,  # type: bool
         timeout=1 * 60 * 60,  # type: typing.Optional[int]
@@ -227,13 +225,15 @@ Possible to call commands in parallel on multiple hosts if it's not produce huge
 
 .. code-block:: python
 
-    results = SSHClient.execute_together(
+    results: Dict[Tuple[str, int], ExecResult] = SSHClient.execute_together(
         remotes,  # type: typing.Iterable[SSHClient]
         command,  # type: str
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
         expected=(0,),  # type: typing.Iterable[typing.Union[int, ExitCodes]]
         raise_on_err=True,  # type: bool
         # Keyword only:
+        stdin=None,  # type: typing.Union[bytes, str, bytearray, None]
+        log_mask_re=None,  # type: typing.Optional[str]
         exception_class=ParallelCallProcessError  # typing.Type[ParallelCallProcessError]
     )
     results  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
@@ -245,7 +245,7 @@ For execute through SSH host can be used `execute_through_host` method:
 
 .. code-block:: python
 
-    result = client.execute_through_host(
+    result: ExecResult = client.execute_through_host(
         hostname,  # type: str
         command,  # type: str
         auth=None,  # type: typing.Optional[SSHAuth]
@@ -253,6 +253,8 @@ For execute through SSH host can be used `execute_through_host` method:
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
         verbose=False,  # type: bool
         # Keyword only:
+        stdin=None,  # type: typing.Union[bytes, str, bytearray, None]
+        log_mask_re=None,  # type: typing.Optional[str]
         get_pty=False,  # type: bool
         width=80,  # type: int
         height=24  # type: int
@@ -347,7 +349,7 @@ Example:
 .. code-block:: python
 
     async with helper:
-      result = await helper.execute(
+      result: ExecResult = await helper.execute(
           command,  # type: str
           verbose=False,  # type: bool
           timeout=1 * 60 * 60,  # type: typing.Union[int, float, None]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,6 +2,12 @@
 # Create and test a Python package on multiple Python versions.
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
+trigger:
+- master
+- py35
+pr:
+- master
+- py35
 
 jobs:
 - job: 'PyLint'
@@ -59,16 +65,10 @@ jobs:
       testRunTitle: 'MyPy'
 
 - template: .azure_pipelines/run_tests.yml
-  parameters: {name: 'Python_35', python: '3.5', architecture: 'x64', kind: 'native'}
-- template: .azure_pipelines/run_tests.yml
   parameters: {name: 'Python_36', python: '3.6', architecture: 'x64', kind: 'native'}
 - template: .azure_pipelines/run_tests.yml
   parameters: {name: 'Python_37', python: '3.7', architecture: 'x64', kind: 'native'}
 
-- template: .azure_pipelines/run_tests.yml
-  parameters: {name: 'Python_35', python: '3.5', architecture: 'x64', kind: 'cython'}
-- template: .azure_pipelines/run_tests.yml
-  parameters: {name: 'Python_35', python: '3.5', architecture: 'x86', kind: 'cython'}
 - template: .azure_pipelines/run_tests.yml
   parameters: {name: 'Python_36', python: '3.6', architecture: 'x64', kind: 'cython'}
 - template: .azure_pipelines/run_tests.yml
@@ -80,12 +80,9 @@ jobs:
 
 - job: 'Build_and_deploy'
   dependsOn:
-  - Python_35_x64_native
   - Python_36_x64_native
   - Python_37_x64_native
 
-  - Python_35_x64_cython
-  - Python_35_x86_cython
   - Python_36_x64_cython
   - Python_36_x86_cython
   - Python_37_x64_cython
@@ -96,12 +93,6 @@ jobs:
   strategy:
     maxParallel: 6
     matrix:
-      Python35_x64:
-        python.version: '3.5'
-        python.architecture: 'x64'
-      Python35_x86:
-        python.version: '3.5'
-        python.architecture: 'x86'
       Python36_x64:
         python.version: '3.6'
         python.architecture: 'x64'

--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -233,7 +233,7 @@ API: SSHClient and SSHAuth.
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Exception class can be substituted
 
-    .. py:method:: execute_through_host(hostname, command, auth=None, target_port=22, verbose=False, timeout=1*60*60, *, get_pty=False, width=80, height=24, **kwargs)
+    .. py:method:: execute_through_host(hostname, command, auth=None, target_port=22, verbose=False, timeout=1*60*60, *, stdin=None, log_mask_re="", get_pty=False, width=80, height=24, **kwargs)
 
         Execute command on remote host through currently connected host.
 
@@ -249,6 +249,11 @@ API: SSHClient and SSHAuth.
         :type verbose: ``bool``
         :param timeout: Timeout for command execution.
         :type timeout: ``typing.Union[int, float, None]``
+        :param stdin: pass STDIN text to the process
+        :type stdin: typing.Union[bytes, str, bytearray, None]
+        :param log_mask_re: regex lookup rule to mask command for logger.
+                            all MATCHED groups will be replaced by '<*masked*>'
+        :type log_mask_re: typing.Optional[str]
         :param get_pty: open PTY on target machine
         :type get_pty: ``bool``
         :param width: PTY width
@@ -261,9 +266,9 @@ API: SSHClient and SSHAuth.
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Expose pty options as optional keyword-only arguments
         .. versionchanged:: 3.2.0 Exception class can be substituted
-        .. versionchanged:: 3.4.0 Expected is not optional, defaults os dependent
+        .. versionchanged:: 4.0.0 Expose stdin and log_mask_re as optional keyword-only arguments
 
-    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=(0,), raise_on_err=True, *, exception_class=ParallelCallProcessError, **kwargs)
+    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=(0,), raise_on_err=True, *, stdin=None, log_mask_re="", exception_class=ParallelCallProcessError, **kwargs)
 
         Execute command on multiple remotes in async mode.
 
@@ -277,6 +282,11 @@ API: SSHClient and SSHAuth.
         :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
+        :param stdin: pass STDIN text to the process
+        :type stdin: typing.Union[bytes, str, bytearray, None]
+        :param log_mask_re: regex lookup rule to mask command for logger.
+                            all MATCHED groups will be replaced by '<*masked*>'
+        :type log_mask_re: typing.Optional[str]
         :param exception_class: Exception to raise on error. Mandatory subclass of ParallelCallProcessError
         :type exception_class: typing.Type[ParallelCallProcessError]
         :return: dictionary {(hostname, port): result}
@@ -287,6 +297,7 @@ API: SSHClient and SSHAuth.
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Exception class can be substituted
         .. versionchanged:: 3.4.0 Expected is not optional, defaults os dependent
+        .. versionchanged:: 4.0.0 Expose stdin and log_mask_re as optional keyword-only arguments
 
     .. py:method:: open(path, mode='r')
 

--- a/exec_helpers/__init__.py
+++ b/exec_helpers/__init__.py
@@ -14,7 +14,24 @@
 
 """Execution helpers for simplified usage of subprocess and ssh."""
 
-import typing
+__all__ = (
+    "ExecHelperError",
+    "ExecCalledProcessError",
+    "CalledProcessError",
+    "ParallelCallExceptions",
+    "ParallelCallProcessError",
+    "ExecHelperNoKillError",
+    "ExecHelperTimeoutError",
+    "ExecHelper",
+    "SSHClient",
+    "SshExecuteAsyncResult",
+    "SSHAuth",
+    "Subprocess",
+    "SubprocessExecuteAsyncResult",
+    "ExitCodes",
+    "ExecResult",
+    "async_api",
+)
 
 import pkg_resources
 
@@ -38,27 +55,8 @@ from ._ssh_client_base import SshExecuteAsyncResult
 from .subprocess_runner import Subprocess, SubprocessExecuteAsyncResult  # nosec  # Expected
 from . import async_api
 
-__all__ = (
-    "ExecHelperError",
-    "ExecCalledProcessError",
-    "CalledProcessError",
-    "ParallelCallExceptions",
-    "ParallelCallProcessError",
-    "ExecHelperNoKillError",
-    "ExecHelperTimeoutError",
-    "ExecHelper",
-    "SSHClient",
-    "SshExecuteAsyncResult",
-    "SSHAuth",
-    "Subprocess",
-    "SubprocessExecuteAsyncResult",
-    "ExitCodes",
-    "ExecResult",
-    "async_api",
-)  # type: typing.Tuple[str, ...]
-
 try:  # pragma: no cover
-    __version__ = pkg_resources.get_distribution(__name__).version
+    __version__: str = pkg_resources.get_distribution(__name__).version
 except pkg_resources.DistributionNotFound:  # pragma: no cover
     # package is not installed, try to get from SCM
     try:

--- a/exec_helpers/_log_templates.py
+++ b/exec_helpers/_log_templates.py
@@ -16,17 +16,9 @@
 
 """Text templates for logging."""
 
-CMD_EXEC = "Executing command:\n{cmd!r}\n"
+CMD_EXEC: str = "Executing command:\n{cmd!r}\n"
 
-CMD_KILL_ERROR = (
-    "Wait for {result.cmd!r} during {timeout!s}s: no return code and no response on SIGTERM + SIGKILL signals!\n"
-    "\tSTDOUT:\n"
-    "{result.stdout_brief}\n"
-    "\tSTDERR:\n"
-    "{result.stderr_brief}"
-)
-
-CMD_WAIT_ERROR = (
+CMD_WAIT_ERROR: str = (
     "Wait for {result.cmd!r} during {timeout!s}s: no return code!\n"
     "\tSTDOUT:\n"
     "{result.stdout_brief}\n"

--- a/exec_helpers/_subprocess_helpers.py
+++ b/exec_helpers/_subprocess_helpers.py
@@ -17,11 +17,7 @@
 __all__ = ("kill_proc_tree", "subprocess_kw")
 
 import platform
-
-# pylint: disable=unused-import
-import typing  # noqa: F401
-
-# pylint: enable=unused-import
+import typing
 
 import psutil  # type: ignore
 
@@ -47,7 +43,7 @@ def kill_proc_tree(pid: int, including_parent: bool = True) -> None:  # pragma: 
             pass
 
     parent = psutil.Process(pid)
-    children = parent.children(recursive=True)
+    children: typing.List[psutil.Process] = parent.children(recursive=True)
     for child in children:  # type: psutil.Process
         safe_stop(child)  # SIGTERM to allow cleanup
     _, alive = psutil.wait_procs(children, timeout=1)
@@ -64,7 +60,7 @@ def kill_proc_tree(pid: int, including_parent: bool = True) -> None:  # pragma: 
 # Subprocess extra arguments.
 # Flags from:
 # https://stackoverflow.com/questions/13243807/popen-waiting-for-child-process-even-when-the-immediate-child-has-terminated
-subprocess_kw = {}  # type: typing.Dict[str, typing.Any]
+subprocess_kw: typing.Dict[str, typing.Any] = {}
 if "Windows" == platform.system():  # pragma: no cover
     subprocess_kw["creationflags"] = 0x00000200
 else:  # pragma: no cover

--- a/exec_helpers/async_api/__init__.py
+++ b/exec_helpers/async_api/__init__.py
@@ -17,9 +17,8 @@
 .. versionadded:: 3.0.0
 """
 
+__all__ = ("ExecHelper", "ExecResult", "Subprocess", "SubprocessExecuteAsyncResult")
 
 from .api import ExecHelper
 from .exec_result import ExecResult
 from .subprocess_runner import Subprocess, SubprocessExecuteAsyncResult  # nosec  # Expected
-
-__all__ = ("ExecHelper", "ExecResult", "Subprocess", "SubprocessExecuteAsyncResult")

--- a/exec_helpers/async_api/exec_result.py
+++ b/exec_helpers/async_api/exec_result.py
@@ -17,13 +17,13 @@
 .. versionadded:: 3.0.0
 """
 
+__all__ = ("ExecResult",)
+
 import logging
 import typing
 
 
 from exec_helpers import exec_result
-
-__all__ = ("ExecResult",)
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class ExecResult(exec_result.ExecResult):
     async def _poll_stream(  # type: ignore
         src: typing.AsyncIterable[bytes], log: typing.Optional[logging.Logger] = None, verbose: bool = False
     ) -> typing.List[bytes]:
-        dst = []
+        dst: typing.List[bytes] = []
         try:
             async for line in src:
                 dst.append(line)

--- a/exec_helpers/constants.py
+++ b/exec_helpers/constants.py
@@ -14,9 +14,9 @@
 
 """Global constants."""
 
-MINUTE = 60
-HOUR = 60 * MINUTE
+MINUTE: int = 60
+HOUR: int = 60 * MINUTE
 
 
 # Default command timeout
-DEFAULT_TIMEOUT = 1 * HOUR
+DEFAULT_TIMEOUT: int = 1 * HOUR

--- a/exec_helpers/metaclasses.py
+++ b/exec_helpers/metaclasses.py
@@ -27,8 +27,8 @@ class SingletonMeta(abc.ABCMeta):
     Main goals: not need to implement __new__ in singleton classes
     """
 
-    _instances = {}  # type: typing.Dict[type, typing.Any]
-    _lock = threading.RLock()  # type: threading.RLock
+    _instances: typing.Dict[type, typing.Any] = {}
+    _lock: threading.RLock = threading.RLock()
 
     def __call__(cls: "SingletonMeta", *args: typing.Any, **kwargs: typing.Any) -> typing.Any:
         """Singleton."""
@@ -62,7 +62,7 @@ class SingleLock(abc.ABCMeta):
         name: str,
         bases: typing.Tuple[type, ...],
         namespace: typing.Dict[str, typing.Any],
-        **kwargs: typing.Any
+        **kwargs: typing.Any,
     ) -> "SingleLock":
         """Create lock property for class instances."""
         namespace["lock"] = property(fget=lambda self: self.__class__.lock)

--- a/exec_helpers/proc_enums.py
+++ b/exec_helpers/proc_enums.py
@@ -19,11 +19,11 @@
 Linux signals, Linux & bash return codes.
 """
 
+__all__ = ("SigNum", "ExitCodes", "exit_code_to_enum", "exit_codes_to_enums", "EXPECTED", "INVALID")
+
 import enum
 import sys
 import typing
-
-__all__ = ("SigNum", "ExitCodes", "exit_code_to_enum", "exit_codes_to_enums", "EXPECTED", "INVALID")
 
 
 @enum.unique
@@ -64,7 +64,7 @@ class SigNum(enum.IntEnum):
 
     def __str__(self) -> str:
         """Representation for logs."""
-        return "{self.name}<{self.value:d}(0x{self.value:02X})>".format(self=self)  # pragma: no cover
+        return f"{self.name}<{self.value:d}(0x{self.value:02X})>"  # pragma: no cover
 
 
 @enum.unique
@@ -166,11 +166,11 @@ class ExitCodes(int, enum.Enum):
 
     def __str__(self) -> str:
         """Representation for logs."""
-        return "{self.name}<{self.value:d}(0x{self.value:02X})>".format(self=self)
+        return f"{self.name}<{self.value:d}(0x{self.value:02X})>"
 
 
-EXPECTED = 0 if "win32" == sys.platform else ExitCodes.EX_OK
-INVALID = 0xDEADBEEF if "win32" == sys.platform else ExitCodes.EX_INVALID
+EXPECTED: typing.Union[int, ExitCodes] = 0 if "win32" == sys.platform else ExitCodes.EX_OK
+INVALID: typing.Union[int, ExitCodes] = 0xDEADBEEF if "win32" == sys.platform else ExitCodes.EX_INVALID
 
 
 def exit_code_to_enum(code: typing.Union[int, ExitCodes]) -> typing.Union[int, ExitCodes]:
@@ -184,8 +184,9 @@ def exit_code_to_enum(code: typing.Union[int, ExitCodes]) -> typing.Union[int, E
 
 def exit_codes_to_enums(
     codes: typing.Optional[typing.Iterable[typing.Union[int, ExitCodes]]] = None
-) -> typing.Iterable[typing.Union[int, ExitCodes]]:
+) -> typing.Tuple[typing.Union[int, ExitCodes], ...]:
     """Convert integer exit codes to enums."""
     if codes is None:
+        # noinspection PyRedundantParentheses
         return (EXPECTED,)
     return tuple(exit_code_to_enum(code) for code in codes)

--- a/exec_helpers/ssh_client.py
+++ b/exec_helpers/ssh_client.py
@@ -16,14 +16,14 @@
 
 """SSH client helper based on Paramiko. Extended API helpers."""
 
+__all__ = ("SSHClient",)
+
 import logging
 import os
 import posixpath
 
 
 from ._ssh_client_base import SSHClientBase
-
-__all__ = ("SSHClient",)
 
 logger = logging.getLogger(__name__)
 
@@ -73,13 +73,13 @@ class SSHClient(SSHClientBase):
             return
 
         for rootdir, _, files in os.walk(source):
-            targetdir = os.path.normpath(os.path.join(target, os.path.relpath(rootdir, source))).replace("\\", "/")
+            targetdir: str = os.path.normpath(os.path.join(target, os.path.relpath(rootdir, source))).replace("\\", "/")
 
             self.mkdir(targetdir)
 
             for entry in files:
-                local_path = os.path.normpath(os.path.join(rootdir, entry))
-                remote_path = posixpath.join(targetdir, entry)
+                local_path: str = os.path.normpath(os.path.join(rootdir, entry))
+                remote_path: str = posixpath.join(targetdir, entry)
                 if self.exists(remote_path):
                     self._sftp.unlink(remote_path)
                 self._sftp.put(local_path, remote_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,4 @@ requires = [
 [tool.black]
 line-length = 120
 safe = true
-py36 = false
+py36 = true

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -238,7 +237,7 @@ setup_args = dict(
     long_description=long_description,
     classifiers=classifiers,
     keywords=keywords,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     # While setuptools cannot deal with pre-installed incompatible versions,
     # setting a lower bound is not harmful - it makes error messages cleaner. DO
     # NOT set an upper bound on setuptools, as that will lead to uninstallable

--- a/test/async_api/test_subprocess.py
+++ b/test/async_api/test_subprocess.py
@@ -155,7 +155,7 @@ def create_subprocess_shell(mocker, monkeypatch, run_parameters):
         stdout: typing.Optional[typing.Tuple] = None,
         stderr: typing.Optional[typing.Tuple] = None,
         stdin: typing.Optional[typing.Union[str, bytes, bytearray]] = None,
-        **kwargs
+        **kwargs,
     ):
         """Parametrized code."""
         proc = asynctest.CoroutineMock()
@@ -236,7 +236,7 @@ async def test_001_execute_async(create_subprocess_shell, logger, run_parameters
         cwd=run_parameters.get("cwd", None),
         env=run_parameters.get("env", None),
         universal_newlines=False,
-        **_subprocess_helpers.subprocess_kw
+        **_subprocess_helpers.subprocess_kw,
     )
 
     if stdin is not None:
@@ -251,7 +251,7 @@ async def test_002_execute(create_subprocess_shell, logger, exec_result, run_par
     assert isinstance(res, exec_helpers.async_api.ExecResult)
     assert res == exec_result
     assert logger.mock_calls[-1] == mock.call.log(
-        level=logging.DEBUG, msg="Command {result.cmd!r} exit code: {result.exit_code!s}".format(result=res)
+        level=logging.DEBUG, msg=f"Command {res.cmd!r} exit code: {res.exit_code!s}"
     )
 
 
@@ -279,7 +279,7 @@ async def test_004_check_call(execute, exec_result, logger) -> None:
         with pytest.raises(exec_helpers.CalledProcessError) as e:
             await runner.check_call(command, stdin=exec_result.stdin)
 
-        exc = e.value  # type: exec_helpers.CalledProcessError
+        exc: exec_helpers.CalledProcessError = e.value
         assert exc.cmd == exec_result.cmd
         assert exc.returncode == exec_result.exit_code
         assert exc.stdout == exec_result.stdout_str
@@ -288,9 +288,8 @@ async def test_004_check_call(execute, exec_result, logger) -> None:
         assert exc.expected == (proc_enums.EXPECTED,)
 
         assert logger.mock_calls[-1] == mock.call.error(
-            msg="Command {result.cmd!r} returned exit code {result.exit_code!s} while expected {expected!r}".format(
-                result=exc.result, expected=exc.expected
-            )
+            msg=f"Command {exc.result.cmd!r} returned exit code {exc.result.exit_code!s}"
+            f" while expected {exc.expected!r}"
         )
 
 
@@ -298,12 +297,11 @@ async def test_005_check_call_no_raise(execute, exec_result, logger) -> None:
     runner = exec_helpers.async_api.Subprocess()
     res = await runner.check_call(command, stdin=exec_result.stdin, raise_on_err=False)
     assert res == exec_result
+    expected = (proc_enums.EXPECTED,)
 
     if exec_result.exit_code != exec_helpers.ExitCodes.EX_OK:
         assert logger.mock_calls[-1] == mock.call.error(
-            msg="Command {result.cmd!r} returned exit code {result.exit_code!s} while expected {expected!r}".format(
-                result=res, expected=(proc_enums.EXPECTED,)
-            )
+            msg=f"Command {res.cmd!r} returned exit code {res.exit_code!s} while expected {expected!r}"
         )
 
 
@@ -322,7 +320,7 @@ async def test_007_check_stderr(execute, exec_result, logger) -> None:
         with pytest.raises(exec_helpers.CalledProcessError) as e:
             await runner.check_stderr(command, stdin=exec_result.stdin, expected=[exec_result.exit_code])
 
-        exc = e.value  # type: exec_helpers.CalledProcessError
+        exc: exec_helpers.CalledProcessError = e.value
         assert exc.result == exec_result
         assert exc.cmd == exec_result.cmd
         assert exc.returncode == exec_result.exit_code
@@ -331,8 +329,8 @@ async def test_007_check_stderr(execute, exec_result, logger) -> None:
         assert exc.result == exec_result
 
         assert logger.mock_calls[-1] == mock.call.error(
-            msg="Command {result.cmd!r} output contains STDERR while not expected\n"
-            "\texit code: {result.exit_code!s}".format(result=exc.result)
+            msg=f"Command {exc.result.cmd!r} output contains STDERR while not expected\n"
+            f"\texit code: {exc.result.exit_code!s}"
         )
 
 
@@ -352,5 +350,5 @@ async def test_009_call(create_subprocess_shell, logger, exec_result, run_parame
     assert isinstance(res, exec_helpers.async_api.ExecResult)
     assert res == exec_result
     assert logger.mock_calls[-1] == mock.call.log(
-        level=logging.DEBUG, msg="Command {result.cmd!r} exit code: {result.exit_code!s}".format(result=res)
+        level=logging.DEBUG, msg=f"Command {res.cmd!r} exit code: {res.exit_code!s}"
     )

--- a/test/async_api/test_subprocess_special.py
+++ b/test/async_api/test_subprocess_special.py
@@ -156,7 +156,7 @@ def create_subprocess_shell(mocker, monkeypatch, run_parameters):
     def create_mock(
         stdout: typing.Optional[typing.Tuple] = None,
         stdin: typing.Optional[typing.Union[str, bytes, bytearray]] = None,
-        **kwargs
+        **kwargs,
     ):
         """Parametrized code."""
         proc = asynctest.CoroutineMock()

--- a/test/test_exec_result.py
+++ b/test/test_exec_result.py
@@ -55,11 +55,7 @@ class TestExecResult(unittest.TestCase):
             repr(result),
             "{cls}(cmd={cmd!r}, stdout={stdout}, stderr={stderr}, "
             "exit_code={exit_code!s})".format(
-                cls=exec_helpers.ExecResult.__name__,
-                cmd=cmd,
-                stdout=(),
-                stderr=(),
-                exit_code=proc_enums.INVALID,
+                cls=exec_helpers.ExecResult.__name__, cmd=cmd, stdout=(), stderr=(), exit_code=proc_enums.INVALID
             ),
         )
         self.assertEqual(
@@ -83,18 +79,10 @@ class TestExecResult(unittest.TestCase):
         with self.assertRaises(exec_helpers.ExecHelperError):
             # noinspection PyStatementEffect
             result["stdout_json"]  # pylint: disable=pointless-statement
-        logger.assert_has_calls(
-            (
-                mock.call.exception(
-                    "{cmd} stdout is not valid json:\n" "{stdout_str!r}\n".format(cmd=cmd, stdout_str="")
-                ),
-            )
-        )
+        logger.assert_has_calls((mock.call.exception(f"{cmd} stdout is not valid json:\n{result.stdout_str!r}\n"),))
         self.assertIsNone(result["stdout_yaml"])
 
-        self.assertEqual(
-            hash(result), hash((exec_helpers.ExecResult, cmd, None, (), (), proc_enums.INVALID))
-        )
+        self.assertEqual(hash(result), hash((exec_helpers.ExecResult, cmd, None, (), (), proc_enums.INVALID)))
 
     @mock.patch("exec_helpers.exec_result.logger", autospec=True)
     def test_not_implemented(self, logger):
@@ -159,13 +147,7 @@ class TestExecResult(unittest.TestCase):
         with self.assertRaises(exec_helpers.ExecHelperError):
             # noinspection PyStatementEffect
             result.stdout_json  # pylint: disable=pointless-statement
-        logger.assert_has_calls(
-            (
-                mock.call.exception(
-                    "{cmd} stdout is not valid json:\n" "{stdout_str!r}\n".format(cmd=cmd, stdout_str="")
-                ),
-            )
-        )
+        logger.assert_has_calls((mock.call.exception(f"{cmd} stdout is not valid json:\n{result.stdout_str!r}\n"),))
         self.assertIsNone(result["stdout_yaml"])
 
     def test_not_equal(self):

--- a/test/test_sftp.py
+++ b/test/test_sftp.py
@@ -173,7 +173,7 @@ class TestSftp(unittest.TestCase):
         # noinspection PyTypeChecker
         ssh.mkdir(dst)
         exists.assert_called_once_with(dst)
-        execute.assert_called_once_with("mkdir -p {}\n".format(escaped_dst))
+        execute.assert_called_once_with(f"mkdir -p {escaped_dst}\n")
 
         # Path exists
         exists.reset_mock()
@@ -196,7 +196,7 @@ class TestSftp(unittest.TestCase):
         # Path not exists
         # noinspection PyTypeChecker
         ssh.rm_rf(dst)
-        execute.assert_called_once_with("rm -rf {}".format(dst))
+        execute.assert_called_once_with(f"rm -rf {dst}")
 
     def test_open(self, client, *args):
         ssh, _sftp = self.prepare_sftp_file_tests(client)

--- a/test/test_ssh_client_execute_async_special.py
+++ b/test/test_ssh_client_execute_async_special.py
@@ -89,7 +89,7 @@ def chan_makefile():
                 self.stdout = FakeFileStream(*stdout_src)
                 self.stdout.channel = self.channel
                 return self.stdout
-            raise ValueError("Unexpected flags: {!r}".format(flags))
+            raise ValueError(f"Unexpected flags: {flags!r}")
 
     return MkFile()
 
@@ -144,7 +144,7 @@ def test_001_execute_async_sudo(ssh, ssh_transport_channel):
     ssh_transport_channel.assert_has_calls(
         (
             mock.call.makefile_stderr("rb"),
-            mock.call.exec_command("sudo -S bash -c '" 'eval "$(base64 -d <(echo "{0}"))"\''.format(encoded_cmd)),
+            mock.call.exec_command(f'sudo -S bash -c \'eval "$(base64 -d <(echo "{encoded_cmd}"))"\''),
         )
     )
 
@@ -157,7 +157,7 @@ def test_002_execute_async_with_sudo_enforce(ssh, ssh_transport_channel):
     ssh_transport_channel.assert_has_calls(
         (
             mock.call.makefile_stderr("rb"),
-            mock.call.exec_command("sudo -S bash -c '" 'eval "$(base64 -d <(echo "{0}"))"\''.format(encoded_cmd)),
+            mock.call.exec_command(f'sudo -S bash -c \'eval "$(base64 -d <(echo "{encoded_cmd}"))"\''),
         )
     )
 
@@ -167,9 +167,7 @@ def test_003_execute_async_with_no_sudo_enforce(ssh, ssh_transport_channel):
 
     with ssh.sudo(enforce=False):
         ssh.execute_async(command)
-    ssh_transport_channel.assert_has_calls(
-        (mock.call.makefile_stderr("rb"), mock.call.exec_command("{}\n".format(command)))
-    )
+    ssh_transport_channel.assert_has_calls((mock.call.makefile_stderr("rb"), mock.call.exec_command(f"{command}\n")))
 
 
 def test_004_execute_async_with_sudo_none_enforce(ssh, ssh_transport_channel):
@@ -177,9 +175,7 @@ def test_004_execute_async_with_sudo_none_enforce(ssh, ssh_transport_channel):
 
     with ssh.sudo():
         ssh.execute_async(command)
-    ssh_transport_channel.assert_has_calls(
-        (mock.call.makefile_stderr("rb"), mock.call.exec_command("{}\n".format(command)))
-    )
+    ssh_transport_channel.assert_has_calls((mock.call.makefile_stderr("rb"), mock.call.exec_command(f"{command}\n")))
 
 
 def test_005_execute_async_sudo_password(ssh, ssh_transport_channel, mocker):
@@ -191,7 +187,7 @@ def test_005_execute_async_sudo_password(ssh, ssh_transport_channel, mocker):
     ssh_transport_channel.assert_has_calls(
         (
             mock.call.makefile_stderr("rb"),
-            mock.call.exec_command("sudo -S bash -c '" 'eval "$(base64 -d <(echo "{0}"))"\''.format(encoded_cmd)),
+            mock.call.exec_command(f'sudo -S bash -c \'eval "$(base64 -d <(echo "{encoded_cmd}"))"\''),
         )
     )
 
@@ -251,5 +247,5 @@ def test_010_check_stdin_closed(paramiko_ssh_client, chan_makefile, auto_add_pol
     ssh = exec_helpers.SSHClient(host=host, port=port, auth=exec_helpers.SSHAuth(username=username, password=password))
     ssh.execute_async(command=print_stdin, stdin=stdin_val)
 
-    log = get_logger(ssh.__class__.__name__).getChild("{host}:{port}".format(host=host, port=port))
+    log = get_logger(ssh.__class__.__name__).getChild(f"{host}:{port}")
     log.warning.assert_called_once_with("STDIN Send failed: closed channel")

--- a/test/test_ssh_client_execute_special.py
+++ b/test/test_ssh_client_execute_special.py
@@ -93,7 +93,7 @@ def chan_makefile():
                 self.stdout = FakeFileStream(*stdout_src)
                 self.stdout.channel = self.channel
                 return self.stdout
-            raise ValueError("Unexpected flags: {!r}".format(flags))
+            raise ValueError(f"Unexpected flags: {flags!r}")
 
     return MkFile()
 
@@ -152,10 +152,10 @@ def test_001_mask_command(ssh, get_logger) -> None:
     cmd = "USE='secret=secret_pass' do task"
     log_mask_re = r"secret\s*=\s*([A-Z-a-z0-9_\-]+)"
     masked_cmd = "USE='secret=<*masked*>' do task"
-    cmd_log = "Executing command:\n{!r}\n".format(masked_cmd)
-    done_log = "Command {!r} exit code: {!s}".format(masked_cmd, proc_enums.EXPECTED)
+    cmd_log = f"Executing command:\n{masked_cmd!r}\n"
+    done_log = f"Command {masked_cmd!r} exit code: {proc_enums.EXPECTED!s}"
 
-    log = get_logger(ssh.__class__.__name__).getChild("{host}:{port}".format(host=host, port=port))
+    log = get_logger(ssh.__class__.__name__).getChild(f"{host}:{port}")
     res = ssh.execute(cmd, log_mask_re=log_mask_re)
     assert res.cmd == masked_cmd
     assert log.mock_calls[0] == mock.call.log(level=logging.DEBUG, msg=cmd_log)
@@ -166,10 +166,10 @@ def test_002_mask_command_global(ssh, get_logger) -> None:
     cmd = "USE='secret=secret_pass' do task"
     log_mask_re = r"secret\s*=\s*([A-Z-a-z0-9_\-]+)"
     masked_cmd = "USE='secret=<*masked*>' do task"
-    cmd_log = "Executing command:\n{!r}\n".format(masked_cmd)
-    done_log = "Command {!r} exit code: {!s}".format(masked_cmd, proc_enums.EXPECTED)
+    cmd_log = f"Executing command:\n{masked_cmd!r}\n"
+    done_log = f"Command {masked_cmd!r} exit code: {proc_enums.EXPECTED!s}"
 
-    log = get_logger(ssh.__class__.__name__).getChild("{host}:{port}".format(host=host, port=port))
+    log = get_logger(ssh.__class__.__name__).getChild(f"{host}:{port}")
 
     ssh.log_mask_re = log_mask_re
     res = ssh.execute(cmd)
@@ -179,10 +179,10 @@ def test_002_mask_command_global(ssh, get_logger) -> None:
 
 
 def test_003_execute_verbose(ssh, get_logger) -> None:
-    cmd_log = "Executing command:\n{!r}\n".format(command)
-    done_log = "Command {!r} exit code: {!s}".format(command, proc_enums.EXPECTED)
+    cmd_log = f"Executing command:\n{command!r}\n"
+    done_log = f"Command {command!r} exit code: {proc_enums.EXPECTED!s}"
 
-    log = get_logger(ssh.__class__.__name__).getChild("{host}:{port}".format(host=host, port=port))
+    log = get_logger(ssh.__class__.__name__).getChild(f"{host}:{port}")
     ssh.execute(command, verbose=True)
 
     assert log.mock_calls[0] == mock.call.log(level=logging.INFO, msg=cmd_log)
@@ -199,7 +199,7 @@ def test_005_execute_timeout_fail(ssh, ssh_transport_channel, exec_result) -> No
     ssh_transport_channel.status_event = threading.Event()
     with pytest.raises(exec_helpers.ExecHelperTimeoutError) as e:
         ssh.execute(command, timeout=0.01)
-    exc = e.value  # type: exec_helpers.ExecHelperTimeoutError
+    exc: exec_helpers.ExecHelperTimeoutError = e.value
     assert exc.timeout == 0.01
     assert exc.cmd == command
     assert exc.stdout == exec_result.stdout_str
@@ -212,7 +212,7 @@ def test_006_execute_together_exceptions(ssh, ssh2, mocker) -> None:
 
     with pytest.raises(exec_helpers.ParallelCallExceptions) as e:
         ssh.execute_together(remotes=remotes, command=command)
-    exc = e.value  # type: exec_helpers.ParallelCallExceptions
+    exc: exec_helpers.ParallelCallExceptions = e.value
     assert list(sorted(exc.exceptions)) == [(host, port), (host2, port)]
     for exception in exc.exceptions.values():
         assert isinstance(exception, RuntimeError)

--- a/test/test_ssh_client_execute_throw_host.py
+++ b/test/test_ssh_client_execute_throw_host.py
@@ -89,7 +89,7 @@ def chan_makefile():
                 self.stdout = FakeFileStream(*stdout_src)
                 self.stdout.channel = self.channel
                 return self.stdout
-            raise ValueError("Unexpected flags: {!r}".format(flags))
+            raise ValueError(f"Unexpected flags: {flags!r}")
 
     return MkFile()
 
@@ -200,5 +200,5 @@ def test_05_execute_closed_stdin(ssh, ssh_transport_channel, get_logger) -> None
     ssh_transport_channel.closed = True
 
     ssh.execute_through_host(target, cmd, stdin=stdin, get_pty=True)
-    log = get_logger(ssh.__class__.__name__).getChild("{host}:{port}".format(host=host, port=port))
+    log = get_logger(ssh.__class__.__name__).getChild(f"{host}:{port}")
     log.warning.assert_called_once_with("STDIN Send failed: closed channel")

--- a/test/test_ssh_client_init_special.py
+++ b/test/test_ssh_client_init_special.py
@@ -97,9 +97,7 @@ def test_001_require_key(paramiko_ssh_client, auto_add_policy, ssh_auth_logger):
     paramiko_ssh_client.assert_called_once()
     auto_add_policy.assert_called_once()
 
-    ssh_auth_logger.debug.assert_called_once_with(
-        "Main key has been updated, public key is: \n" "{}".format(ssh.auth.public_key)
-    )
+    ssh_auth_logger.debug.assert_called_once_with("Main key has been updated, public key is: \n%s", ssh.auth.public_key)
 
     pkey = private_keys[0]
 
@@ -134,9 +132,7 @@ def test_002_use_next_key(paramiko_ssh_client, auto_add_policy, ssh_auth_logger)
     paramiko_ssh_client.assert_called_once()
     auto_add_policy.assert_called_once()
 
-    ssh_auth_logger.debug.assert_called_once_with(
-        "Main key has been updated, public key is: \n" "{}".format(ssh.auth.public_key)
-    )
+    ssh_auth_logger.debug.assert_called_once_with("Main key has been updated, public key is: \n%s", ssh.auth.public_key)
 
     kwargs = dict(hostname=host, pkey=None, port=port, username=username, password=None)
     kwargs0 = {key: kwargs[key] for key in kwargs}
@@ -258,7 +254,9 @@ def test_009_auth_pass_no_key(paramiko_ssh_client, auto_add_policy, ssh_auth_log
     # Test
     ssh = exec_helpers.SSHClient(host=host, auth=exec_helpers.SSHAuth(username=username, password=password, key=key))
 
-    ssh_auth_logger.assert_has_calls((mock.call.debug("Main key has been updated, public key is: \nNone"),))
+    ssh_auth_logger.assert_has_calls(
+        (mock.call.debug("Main key has been updated, public key is: \n%s", ssh.auth.public_key),)
+    )
 
     assert ssh.auth == exec_helpers.SSHAuth(username=username, password=password, keys=[key])
 
@@ -294,7 +292,7 @@ def test_011_clear_failed(paramiko_ssh_client, auto_add_policy, ssh_auth_logger,
     paramiko_ssh_client.return_value = _ssh
 
     ssh_logger = get_logger(exec_helpers.SSHClient.__name__)
-    log = ssh_logger.getChild("{host}:{port}".format(host=host, port=port))
+    log = ssh_logger.getChild(f"{host}:{port}")
 
     # Test
     ssh = exec_helpers.SSHClient(host=host, auth=exec_helpers.SSHAuth())
@@ -355,7 +353,7 @@ def test_013_no_sftp(paramiko_ssh_client, auto_add_policy, ssh_auth_logger, get_
     paramiko_ssh_client.return_value = _ssh
 
     ssh_logger = get_logger(exec_helpers.SSHClient.__name__)
-    log = ssh_logger.getChild("{host}:{port}".format(host=host, port=port))
+    log = ssh_logger.getChild(f"{host}:{port}")
     # Test
     ssh = exec_helpers.SSHClient(host=host, auth=exec_helpers.SSHAuth(password=password))
 
@@ -382,7 +380,7 @@ def test_014_sftp_repair(paramiko_ssh_client, auto_add_policy, ssh_auth_logger, 
     paramiko_ssh_client.return_value = _ssh
 
     ssh_logger = get_logger(exec_helpers.SSHClient.__name__)
-    log = ssh_logger.getChild("{host}:{port}".format(host=host, port=port))
+    log = ssh_logger.getChild(f"{host}:{port}")
     # Test
     ssh = exec_helpers.SSHClient(host=host, auth=exec_helpers.SSHAuth(password=password))
 

--- a/test/test_sshauth.py
+++ b/test/test_sshauth.py
@@ -38,7 +38,7 @@ def gen_public_key(private_key: typing.Optional[paramiko.RSAKey] = None) -> str:
 def get_internal_keys(
     key: typing.Optional[paramiko.RSAKey] = None,
     keys: typing.Optional[typing.Iterable[paramiko.RSAKey]] = None,
-    **kwargs
+    **kwargs,
 ):
     int_keys = [None]
     if key is not None:
@@ -113,7 +113,7 @@ def test_001_init_checks(run_parameters) -> None:
     else:
         assert auth.public_key is None
 
-    _key = None if auth.public_key is None else "<private for pub: {}>".format(auth.public_key)
+    _key = None if auth.public_key is None else f"<private for pub: {auth.public_key}>"
     _keys = []
     for k in int_keys:
         if k == key:

--- a/test/test_subprocess.py
+++ b/test/test_subprocess.py
@@ -145,7 +145,7 @@ def popen(mocker, run_parameters):
         ec: typing.Union[exec_helpers.ExitCodes, int] = exec_helpers.ExitCodes.EX_OK,
         stdout: typing.Optional[typing.Tuple] = None,
         stderr: typing.Optional[typing.Tuple] = None,
-        **kwargs
+        **kwargs,
     ):
         """Parametrized code."""
         proc = mock.Mock()
@@ -218,7 +218,7 @@ def test_001_execute_async(popen, logger, run_parameters) -> None:
         cwd=run_parameters.get("cwd", None),
         env=run_parameters.get("env", None),
         universal_newlines=False,
-        **_subprocess_helpers.subprocess_kw
+        **_subprocess_helpers.subprocess_kw,
     )
 
     if stdin is not None:
@@ -258,7 +258,7 @@ def test_004_check_call(execute, exec_result, logger) -> None:
         with pytest.raises(exec_helpers.CalledProcessError) as e:
             runner.check_call(command, stdin=exec_result.stdin)
 
-        exc = e.value  # type: exec_helpers.CalledProcessError
+        exc: exec_helpers.CalledProcessError = e.value
         assert exc.cmd == exec_result.cmd
         assert exc.returncode == exec_result.exit_code
         assert exc.stdout == exec_result.stdout_str
@@ -267,9 +267,8 @@ def test_004_check_call(execute, exec_result, logger) -> None:
         assert exc.expected == (proc_enums.EXPECTED,)
 
         assert logger.mock_calls[-1] == mock.call.error(
-            msg="Command {result.cmd!r} returned exit code {result.exit_code!s} while expected {expected!r}".format(
-                result=exc.result, expected=exc.expected
-            )
+            msg=f"Command {exc.result.cmd!r} returned exit code {exc.result.exit_code!s} "
+            f"while expected {exc.expected!r}"
         )
 
 
@@ -279,10 +278,9 @@ def test_005_check_call_no_raise(execute, exec_result, logger) -> None:
     assert res == exec_result
 
     if exec_result.exit_code != exec_helpers.ExitCodes.EX_OK:
+        expected = (proc_enums.EXPECTED,)
         assert logger.mock_calls[-1] == mock.call.error(
-            msg="Command {result.cmd!r} returned exit code {result.exit_code!s} while expected {expected!r}".format(
-                result=res, expected=(proc_enums.EXPECTED,)
-            )
+            msg=f"Command {res.cmd!r} returned exit code {res.exit_code!s} while expected {expected!r}"
         )
 
 
@@ -298,7 +296,7 @@ def test_007_check_stderr(execute, exec_result, logger) -> None:
     else:
         with pytest.raises(exec_helpers.CalledProcessError) as e:
             runner.check_stderr(command, stdin=exec_result.stdin, expected=[exec_result.exit_code])
-        exc = e.value  # type: exec_helpers.CalledProcessError
+        exc: exec_helpers.CalledProcessError = e.value
         assert exc.result == exec_result
         assert exc.cmd == exec_result.cmd
         assert exc.returncode == exec_result.exit_code
@@ -307,8 +305,8 @@ def test_007_check_stderr(execute, exec_result, logger) -> None:
         assert exc.result == exec_result
 
         assert logger.mock_calls[-1] == mock.call.error(
-            msg="Command {result.cmd!r} output contains STDERR while not expected\n"
-            "\texit code: {result.exit_code!s}".format(result=exc.result)
+            msg=f"Command {exc.result.cmd!r} output contains STDERR while not expected\n"
+            f"\texit code: {exc.result.exit_code!s}"
         )
 
 

--- a/test/test_subprocess_special.py
+++ b/test/test_subprocess_special.py
@@ -154,7 +154,7 @@ def create_subprocess_shell(mocker, run_parameters):
     def create_mock(
         stdout: typing.Optional[typing.Tuple] = None,
         stdin: typing.Optional[typing.Union[str, bytes, bytearray]] = None,
-        **kwargs
+        **kwargs,
     ):
         """Parametrized code."""
         proc = mock.Mock()

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-PYTHON_VERSIONS="cp35-cp35m cp36-cp36m cp37-cp37m"
+PYTHON_VERSIONS="cp36-cp36m cp37-cp37m"
 
 # Avoid creation of __pycache__/*.py[c|o]
 export PYTHONDONTWRITEBYTECODE=1

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 minversion = 2.0
-envlist = pep8, pylint, mypy, bandit, pep257, py{35,36,37,py3}, docs, py{35,36,37}-nocov
+envlist = black, pep8, pylint, mypy, bandit, pep257, py{36,37}, docs, py{36,37}-nocov
 skipsdist = True
 skip_missing_interpreters = True
 
@@ -30,13 +30,6 @@ commands =
     pip freeze
     py.test --junitxml=unit_result.xml --cov-report html --self-contained-html --html=report.html --cov-config .coveragerc --cov=exec_helpers {posargs:test}
     coverage report --fail-under 97
-
-[testenv:py35-nocov]
-usedevelop = False
-commands =
-    python setup.py bdist_wheel
-    pip install exec_helpers --no-index -f dist
-    py.test -vvv {posargs:test}
 
 [testenv:py36-nocov]
 usedevelop = False


### PR DESCRIPTION
Early split python 3.5 due to useful features in python 3.6 (typing)
* f strings (faster)
* type annotations for calls (already helped to find 1 issue)