### PR TITLE
Update docs: expected is not optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Pros:
 * Open Source: https://github.com/python-useful-helpers/exec-helpers
 * PyPI packaged: https://pypi.python.org/pypi/exec-helpers
 * Self-documented code: docstrings with types in comments
-* Tested: see bages on top
+* Tested: see badges on top
 * Support multiple Python versions:
 
 ::
@@ -49,7 +49,7 @@ Pros:
     Python 3.7
     PyPy3 3.5+
 
-.. note:: For Python 2.7 and PyPy please use versions 1.x.x. For python 3.5+ use versions 3.0+
+.. note:: Pythons: For Python 2.7 and PyPy use versions 1.x.x, python 3.5+ use versions 3.x.x, python 3.6+ use versions 4+
 
 This package includes:
 
@@ -100,7 +100,7 @@ Creation from scratch:
     )
 
 Key is a main connection key (always tried first) and keys are alternate keys.
-Key filename is afilename or list of filenames with keys, which should be loaded.
+Key filename is a filename or list of filenames with keys, which should be loaded.
 Passphrase is an alternate password for keys, if it differs from main password.
 If main key now correct for username - alternate keys tried, if correct key found - it became main.
 If no working key - password is used and None is set as main key.
@@ -226,9 +226,11 @@ Possible to call commands in parallel on multiple hosts if it's not produce huge
         remotes,  # type: typing.Iterable[SSHClient]
         command,  # type: str
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
-        expected=None,  # type: typing.Optional[typing.Iterable[int]]
+        expected=(0,),  # type: typing.Iterable[typing.Union[int, ExitCodes]]
         raise_on_err=True,  # type: bool
         # Keyword only:
+        stdin=None,  # type: typing.Union[bytes, str, bytearray, None]
+        log_mask_re=None,  # type: typing.Optional[str]
         exception_class=ParallelCallProcessError  # typing.Type[ParallelCallProcessError]
     )
     results  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
@@ -248,6 +250,8 @@ For execute through SSH host can be used `execute_through_host` method:
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
         verbose=False,  # type: bool
         # Keyword only:
+        stdin=None,  # type: typing.Union[bytes, str, bytearray, None]
+        log_mask_re=None,  # type: typing.Optional[str]
         get_pty=False,  # type: bool
         width=80,  # type: int
         height=24  # type: int

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,19 +5,11 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.1
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.1
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.x" # currently 3.6.0
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
 install:

--- a/doc/source/ExecResult.rst
+++ b/doc/source/ExecResult.rst
@@ -10,7 +10,7 @@ API: ExecResult
 
     Command execution result.
 
-    .. py:method:: __init__(cmd, stdin=None, stdout=None, stderr=None, exit_code=ExitCodes.EX_INVALID)
+    .. py:method:: __init__(cmd, stdin=None, stdout=None, stderr=None, exit_code=0xDEADBEEF, *, started=None)
 
         :param cmd: command
         :type cmd: ``str``
@@ -22,6 +22,8 @@ API: ExecResult
         :type stderr: ``typing.Optional[typing.Iterable[bytes]]``
         :param exit_code: Exit code. If integer - try to convert to BASH enum.
         :type exit_code: typing.Union[int, ExitCodes]
+        :param started: Timestamp of command start
+        :type started: typing.Optional[datetime.datetime]
 
     .. py:attribute:: stdout_lock
 
@@ -41,6 +43,14 @@ API: ExecResult
 
         ``typing.Optional(datetime.datetime)``
         Timestamp
+
+    .. py:method:: set_timestamp()
+
+        Set timestamp if empty.
+
+        This will block future object changes.
+
+        .. versionadded:: 2.11.0
 
     .. py:attribute:: cmd
 
@@ -97,6 +107,13 @@ API: ExecResult
         Return(exit) code of command.
 
         :rtype: typing.Union[int, ExitCodes]
+
+    .. py:attribute:: started
+
+        ``datetime.datetime``
+        Timestamp of command start.
+
+        .. versionadded:: 2.11.0
 
     .. py:attribute:: stdout_json
 

--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -182,7 +182,7 @@ API: SSHClient and SSHAuth.
 
         .. versionadded:: 2.9.4
 
-    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=None, raise_on_err=True, *, exception_class=CalledProcessError, **kwargs)
+    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=(0,), raise_on_err=True, *, exception_class=CalledProcessError, **kwargs)
 
         Execute command and check for return code.
 
@@ -195,7 +195,7 @@ API: SSHClient and SSHAuth.
         :param error_info: Text for error details, if fail happens
         :type error_info: ``typing.Optional[str]``
         :param expected: expected return codes (0 by default)
-        :type expected: ``typing.Optional[typing.Iterable[int]]``
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :param exception_class: Exception class for errors. Subclass of CalledProcessError is mandatory.
@@ -206,8 +206,9 @@ API: SSHClient and SSHAuth.
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Exception class can be substituted
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
-    .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, *, expected=None, exception_class=CalledProcessError, **kwargs)
+    .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, *, expected=(0,), exception_class=CalledProcessError, **kwargs)
 
         Execute command expecting return code 0 and empty STDERR.
 
@@ -222,7 +223,7 @@ API: SSHClient and SSHAuth.
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :param expected: expected return codes (0 by default)
-        :type expected: typing.Optional[typing.Iterable[typing.Union[int, ExitCodes]]]
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param exception_class: Exception class for errors. Subclass of CalledProcessError is mandatory.
         :type exception_class: typing.Type[CalledProcessError]
         :rtype: ExecResult
@@ -232,7 +233,7 @@ API: SSHClient and SSHAuth.
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Exception class can be substituted
 
-    .. py:method:: execute_through_host(hostname, command, auth=None, target_port=22, verbose=False, timeout=1*60*60, *, get_pty=False, width=80, height=24, **kwargs)
+    .. py:method:: execute_through_host(hostname, command, auth=None, target_port=22, verbose=False, timeout=1*60*60, *, stdin=None, log_mask_re="", get_pty=False, width=80, height=24, **kwargs)
 
         Execute command on remote host through currently connected host.
 
@@ -248,6 +249,11 @@ API: SSHClient and SSHAuth.
         :type verbose: ``bool``
         :param timeout: Timeout for command execution.
         :type timeout: ``typing.Union[int, float, None]``
+        :param stdin: pass STDIN text to the process
+        :type stdin: typing.Union[bytes, str, bytearray, None]
+        :param log_mask_re: regex lookup rule to mask command for logger.
+                            all MATCHED groups will be replaced by '<*masked*>'
+        :type log_mask_re: typing.Optional[str]
         :param get_pty: open PTY on target machine
         :type get_pty: ``bool``
         :param width: PTY width
@@ -260,8 +266,9 @@ API: SSHClient and SSHAuth.
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Expose pty options as optional keyword-only arguments
         .. versionchanged:: 3.2.0 Exception class can be substituted
+        .. versionchanged:: 2.11.0 Expose stdin and log_mask_re as optional keyword-only arguments
 
-    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=None, raise_on_err=True, *, exception_class=ParallelCallProcessError, **kwargs)
+    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=(0,), raise_on_err=True, *, stdin=None, log_mask_re="", exception_class=ParallelCallProcessError, **kwargs)
 
         Execute command on multiple remotes in async mode.
 
@@ -272,9 +279,14 @@ API: SSHClient and SSHAuth.
         :param timeout: Timeout for command execution.
         :type timeout: ``typing.Union[int, float, None]``
         :param expected: expected return codes (0 by default)
-        :type expected: ``typing.Optional[typing.Iterable[]]``
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
+        :param stdin: pass STDIN text to the process
+        :type stdin: typing.Union[bytes, str, bytearray, None]
+        :param log_mask_re: regex lookup rule to mask command for logger.
+                            all MATCHED groups will be replaced by '<*masked*>'
+        :type log_mask_re: typing.Optional[str]
         :param exception_class: Exception to raise on error. Mandatory subclass of ParallelCallProcessError
         :type exception_class: typing.Type[ParallelCallProcessError]
         :return: dictionary {(hostname, port): result}
@@ -284,6 +296,8 @@ API: SSHClient and SSHAuth.
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 3.2.0 Exception class can be substituted
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
+        .. versionchanged:: 2.11.0 Expose stdin and log_mask_re as optional keyword-only arguments
 
     .. py:method:: open(path, mode='r')
 
@@ -448,3 +462,9 @@ API: SSHClient and SSHAuth.
     .. py:attribute:: stdout
 
         ``typing.Optional[paramiko.ChannelFile]``
+
+    .. py:attribute:: started
+
+        ``datetime.datetime``
+
+        .. versionadded:: 2.11.0

--- a/doc/source/Subprocess.rst
+++ b/doc/source/Subprocess.rst
@@ -106,7 +106,7 @@ API: Subprocess
         .. note:: stdin channel is closed after the input processing
         .. versionadded:: 2.9.4
 
-    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=None, raise_on_err=True, *, exception_class=CalledProcessError, **kwargs)
+    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=(0,), raise_on_err=True, *, exception_class=CalledProcessError, **kwargs)
 
         Execute command and check for return code.
 
@@ -119,7 +119,7 @@ API: Subprocess
         :param error_info: Text for error details, if fail happens
         :type error_info: ``typing.Optional[str]``
         :param expected: expected return codes (0 by default)
-        :type expected: ``typing.Optional[typing.Iterable[int]]``
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :param exception_class: Exception class for errors. Subclass of CalledProcessError is mandatory.
@@ -131,8 +131,9 @@ API: Subprocess
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 2.9.3 Exception class can be substituted
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
-    .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, *, expected=None, exception_class=CalledProcessError, **kwargs)
+    .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, *, expected=(0,), exception_class=CalledProcessError, **kwargs)
 
         Execute command expecting return code 0 and empty STDERR.
 
@@ -147,7 +148,7 @@ API: Subprocess
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :param expected: expected return codes (0 by default)
-        :type expected: typing.Optional[typing.Iterable[typing.Union[int, ExitCodes]]]
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param exception_class: Exception class for errors. Subclass of CalledProcessError is mandatory.
         :type exception_class: typing.Type[CalledProcessError]
         :rtype: ExecResult
@@ -157,6 +158,7 @@ API: Subprocess
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0 default timeout 1 hour
         .. versionchanged:: 2.9.3 Exception class can be substituted
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
 
 .. py:class:: SubprocessExecuteAsyncResult
@@ -178,3 +180,9 @@ API: Subprocess
     .. py:attribute:: stdout
 
         ``typing.Optional[typing.IO]``
+
+    .. py:attribute:: started
+
+        ``datetime.datetime``
+
+        .. versionadded:: 2.11.0

--- a/doc/source/exceptions.rst
+++ b/doc/source/exceptions.rst
@@ -18,21 +18,11 @@ API: exceptions
 
     Base class for process call errors.
 
-.. py:exception:: ExecHelperTimeoutError(ExecCalledProcessError)
+class ExecHelperTimeoutProcessError(ExecCalledProcessError):
+    
+    Timeout based errors.
 
-    Execution timeout.
-
-    .. versionchanged:: 1.3.0 provide full result and timeout inside.
-    .. versionchanged:: 1.3.0 subclass ExecCalledProcessError
-
-    .. py:method:: __init__(self, result, timeout)
-
-        Exception for error on process calls.
-
-        :param result: execution result
-        :type result: exec_result.ExecResult
-        :param timeout: timeout for command
-        :type timeout: typing.Union[int, float]
+    .. versionadded:: 2.11.0
 
     .. py:attribute:: timeout
 
@@ -54,18 +44,54 @@ API: exceptions
         ``str``
         stdout string or brief string
 
+
+.. py:exception:: ExecHelperNoKillError(ExecHelperTimeoutProcessError)
+    
+    Impossible to kill process.
+
+    .. versionadded:: 2.11.0
+
+    .. py:method:: __init__(self, result, timeout)
+        
+        Exception for error on process calls.
+
+        :param result: execution result
+        :type result: ExecResult
+        :param timeout: timeout for command
+        :type timeout: typing.Union[int, float]
+
+
+.. py:exception:: ExecHelperTimeoutError(ExecHelperTimeoutProcessError)
+
+    Execution timeout.
+
+    .. versionchanged:: 1.3.0 provide full result and timeout inside.
+    .. versionchanged:: 1.3.0 subclass ExecCalledProcessError
+
+    .. py:method:: __init__(self, result, timeout)
+
+        Exception for error on process calls.
+
+        :param result: execution result
+        :type result: ExecResult
+        :param timeout: timeout for command
+        :type timeout: typing.Union[int, float]
+
+
 .. py:exception:: CalledProcessError(ExecCalledProcessError)
 
     Exception for error on process calls.
 
     .. versionchanged:: 1.1.1 - provide full result
 
-    .. py:method:: __init__(result, expected=None)
+    .. py:method:: __init__(result, expected=(0,))
 
         :param result: execution result
         :type result: ExecResult
-        :param returncode: return code
-        :type returncode: typing.Union[int, ExitCodes]
+        :param expected: expected return codes
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
+
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
     .. py:attribute:: result
 
@@ -104,7 +130,7 @@ API: exceptions
 
     Exception during parallel execution.
 
-    .. py:method:: __init__(command, errors, results, expected=None, )
+    .. py:method:: __init__(command, errors, results, expected=(0,), )
 
         :param command: command
         :type command: ``str``
@@ -113,9 +139,10 @@ API: exceptions
         :param results: all results
         :type results: typing.Dict[typing.Tuple[str, int], ExecResult]
         :param expected: expected return codes
-        :type expected: typing.Optional[typing.List[typing.List[typing.Union[int, ExitCodes]]]
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
 
         .. versionchanged:: 1.0 - fixed inheritance
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
     .. py:attribute:: cmd
 
@@ -144,7 +171,7 @@ API: exceptions
 
     Exception raised during parallel call as result of exceptions.
 
-    .. py:method:: __init__(command, exceptions, errors, results, expected=None, )
+    .. py:method:: __init__(command, exceptions, errors, results, expected=(0,), )
 
         :param command: command
         :type command: ``str``
@@ -155,9 +182,10 @@ API: exceptions
         :param results: all results
         :type results: typing.Dict[typing.Tuple[str, int], ExecResult]
         :param expected: expected return codes
-        :type expected: typing.Optional[typing.List[typing.List[typing.Union[int, ExitCodes]]]
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
 
         .. versionchanged:: 1.0 - fixed inheritance
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
     .. py:attribute:: cmd
 

--- a/exec_helpers/api.py
+++ b/exec_helpers/api.py
@@ -22,6 +22,7 @@
 __all__ = ("ExecHelper", "ExecuteAsyncResult")
 
 import abc
+import datetime
 import logging
 import re
 import threading
@@ -40,6 +41,7 @@ ExecuteAsyncResult = typing.NamedTuple(
         ("stdin", typing.Optional[typing.Any]),
         ("stderr", typing.Optional[typing.Any]),
         ("stdout", typing.Optional[typing.Any]),
+        ("started", datetime.datetime),
     ],
 )
 
@@ -171,6 +173,7 @@ class ExecHelper(metaclass=abc.ABCMeta):
                         ('stdin', typing.Optional[typing.Any]),
                         ('stderr', typing.Optional[typing.Any]),
                         ('stdout', typing.Optional[typing.Any]),
+                        ("started", datetime.datetime),
                     ]
                 )
 

--- a/exec_helpers/exec_result.py
+++ b/exec_helpers/exec_result.py
@@ -48,6 +48,7 @@ class ExecResult:
         "_stderr_brief",
         "__stdout_lock",
         "__stderr_lock",
+        "__started",
     ]
 
     def __init__(
@@ -57,6 +58,8 @@ class ExecResult:
         stdout: typing.Optional[typing.Iterable[bytes]] = None,
         stderr: typing.Optional[typing.Iterable[bytes]] = None,
         exit_code: typing.Union[int, proc_enums.ExitCodes] = proc_enums.INVALID,
+        *,
+        started: typing.Optional[datetime.datetime] = None
     ) -> None:
         """Command execution result.
 
@@ -70,6 +73,8 @@ class ExecResult:
         :type stderr: typing.Optional[typing.Iterable[bytes]]
         :param exit_code: Exit code. If integer - try to convert to BASH enum.
         :type exit_code: typing.Union[int, proc_enums.ExitCodes]
+        :param started: Timestamp of command start
+        :type started: typing.Optional[datetime.datetime]
         """
         self.__stdout_lock = threading.RLock()
         self.__stderr_lock = threading.RLock()
@@ -92,8 +97,10 @@ class ExecResult:
             self._stderr = ()
 
         self.__exit_code = proc_enums.INVALID  # type: typing.Union[int, proc_enums.ExitCodes]
-        self.__timestamp = None
+        self.__timestamp = None  # type: typing.Optional[datetime.datetime]
         self.exit_code = exit_code
+
+        self.__started = started  # type: typing.Optional[datetime.datetime]
 
         # By default is none:
         self._stdout_str = None
@@ -131,6 +138,16 @@ class ExecResult:
         :rtype: typing.Optional[datetime.datetime]
         """
         return self.__timestamp
+
+    def set_timestamp(self) -> None:
+        """Set timestamp if empty.
+
+        This will block future object changes.
+
+        .. versionadded:: 2.11.0
+        """
+        if self.timestamp is None:
+            self.__timestamp = datetime.datetime.utcnow()
 
     @staticmethod
     def _get_bytearray_from_array(src: typing.Iterable[bytes]) -> bytearray:
@@ -363,7 +380,15 @@ class ExecResult:
         with self.stdout_lock, self.stderr_lock:
             self.__exit_code = proc_enums.exit_code_to_enum(new_val)
             if self.__exit_code != proc_enums.INVALID:
-                self.__timestamp = datetime.datetime.utcnow()  # type: ignore
+                self.__timestamp = datetime.datetime.utcnow()
+
+    @property
+    def started(self) -> typing.Optional[datetime.datetime]:
+        """Timestamp of command start.
+
+        .. versionadded:: 2.11.0
+        """
+        return self.__started
 
     def __deserialize(self, fmt: str) -> typing.Any:
         """Deserialize stdout as data format.
@@ -443,23 +468,44 @@ class ExecResult:
 
     def __repr__(self) -> str:
         """Representation for debugging."""
+        if self.started:
+            started = ", started={self.started},\n".format(self=self)
+        else:
+            started = ""
         return (
             "{cls}(cmd={self.cmd!r}, stdout={self.stdout}, stderr={self.stderr}, "
-            "exit_code={self.exit_code!s})".format(cls=self.__class__.__name__, self=self)
+            "exit_code={self.exit_code!s}{started},)".format(cls=self.__class__.__name__, self=self, started=started)
         )
 
     def __str__(self) -> str:
         """Representation for logging."""
+        if self.started:
+            started = "\tstarted={started},\n".format(started=self.started.strftime('%Y-%m-%d %H:%M:%S'))
+            if self.timestamp:
+                _spent = (self.timestamp - self.started).seconds
+                spent = "\tspent={hours:02d}:{minutes:02d}:{seconds:02d},\n".format(
+                    hours=_spent // (60 * 60),
+                    minutes=_spent // 60,
+                    seconds=_spent % 60
+                )
+            else:
+                spent = ""
+        else:
+            started = ""
+            spent = ""
         return (
             "{cls}(\n\tcmd={cmd!r},"
             "\n\t stdout=\n'{stdout_brief}',"
             "\n\tstderr=\n'{stderr_brief}', "
-            "\n\texit_code={exit_code!s}\n)".format(
+            "\n\texit_code={exit_code!s},"
+            "\n{started}{spent})".format(
                 cls=self.__class__.__name__,
                 cmd=self.cmd,
                 stdout_brief=self.stdout_brief,
                 stderr_brief=self.stderr_brief,
                 exit_code=self.exit_code,
+                started=started,
+                spent=spent
             )
         )
 

--- a/exec_helpers/proc_enums.py
+++ b/exec_helpers/proc_enums.py
@@ -173,13 +173,13 @@ EXPECTED = 0 if "win32" == sys.platform else ExitCodes.EX_OK
 INVALID = 0xDEADBEEF if "win32" == sys.platform else ExitCodes.EX_INVALID
 
 
-def exit_code_to_enum(code: typing.Union[int, ExitCodes]) -> typing.Union[int, ExitCodes]:
+def exit_code_to_enum(code: typing.Union[int, ExitCodes]) -> typing.Union[int, ExitCodes]:  # pragma: no cover
     """Convert exit code to enum if possible."""
     if "win32" == sys.platform:
         return int(code)
     if isinstance(code, int) and code in ExitCodes.__members__.values():
         return ExitCodes(code)
-    return code  # pragma: no cover
+    return code
 
 
 def exit_codes_to_enums(

--- a/test/test_exec_result.py
+++ b/test/test_exec_result.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=no-self-use
 
+import datetime
 import unittest
 
 import mock
@@ -54,7 +55,7 @@ class TestExecResult(unittest.TestCase):
         self.assertEqual(
             repr(result),
             "{cls}(cmd={cmd!r}, stdout={stdout}, stderr={stderr}, "
-            "exit_code={exit_code!s})".format(
+            "exit_code={exit_code!s},)".format(
                 cls=exec_helpers.ExecResult.__name__,
                 cmd=cmd,
                 stdout=(),
@@ -67,7 +68,7 @@ class TestExecResult(unittest.TestCase):
             "{cls}(\n\tcmd={cmd!r},"
             "\n\t stdout=\n'{stdout_brief}',"
             "\n\tstderr=\n'{stderr_brief}', "
-            "\n\texit_code={exit_code!s}\n)".format(
+            "\n\texit_code={exit_code!s},\n)".format(
                 cls=exec_helpers.ExecResult.__name__,
                 cmd=cmd,
                 stdout_brief="",
@@ -221,3 +222,31 @@ class TestExecResult(unittest.TestCase):
     def test_stdin_bytearray(self):
         result = exec_helpers.ExecResult(cmd, stdin=bytearray(b"STDIN"), exit_code=0)
         self.assertEqual(result.stdin, "STDIN")
+
+    def test_started(self):
+        started = datetime.datetime.utcnow()
+        result = exec_helpers.ExecResult(cmd, exit_code=0, started=started)
+        spent = (result.timestamp - started).seconds
+        self.assertIs(result.started, started)
+        self.assertEqual(
+            str(result),
+            "{cls}(\n\tcmd={cmd!r},"
+            "\n\t stdout=\n'{stdout_brief}',"
+            "\n\tstderr=\n'{stderr_brief}', "
+            "\n\texit_code={exit_code!s},"
+            "\n\tstarted={started},"
+            "\n\tspent={spent},"
+            "\n)".format(
+                cls=exec_helpers.ExecResult.__name__,
+                cmd=cmd,
+                stdout_brief="",
+                stderr_brief="",
+                exit_code=proc_enums.EXPECTED,
+                started=started.strftime("%Y-%m-%d %H:%M:%S"),
+                spent="{hours:02d}:{minutes:02d}:{seconds:02d}".format(
+                    hours=spent // (60 * 60),
+                    minutes=spent // 60,
+                    seconds=spent % 60
+                ),
+            ),
+        )

--- a/test/test_ssh_client_execute.py
+++ b/test/test_ssh_client_execute.py
@@ -12,6 +12,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import datetime
 import logging
 import typing
 
@@ -246,7 +247,7 @@ def execute_async(mocker, run_parameters):
         chan.attach_mock(status_event, "status_event")
         chan.configure_mock(exit_status=exit_code)
         return exec_helpers.SshExecuteAsyncResult(
-            interface=chan, stdin=mock.Mock, stdout=stdout_part, stderr=stderr_part
+            interface=chan, stdin=mock.Mock, stdout=stdout_part, stderr=stderr_part, started=datetime.datetime.utcnow()
         )
 
     return mocker.patch(
@@ -288,7 +289,10 @@ def test_001_execute_async(ssh, paramiko_ssh_client, ssh_transport_channel, chan
     assert isinstance(res, exec_helpers.SshExecuteAsyncResult)
     assert res.interface is ssh_transport_channel
     assert res.stdin is chan_makefile.stdin
-    assert res.stdout is chan_makefile.stdout
+    if open_stdout:
+        assert res.stdout is chan_makefile.stdout
+    else:
+        assert res.stdout is None
 
     paramiko_ssh_client.assert_has_calls(
         (
@@ -480,8 +484,8 @@ def test_009_execute_together(ssh, ssh2, execute_async, exec_result, run_paramet
         )
         execute_async.assert_has_calls(
             (
-                mock.call(command, stdin=run_parameters.get("stdin", None)),
-                mock.call(command, stdin=run_parameters.get("stdin", None)),
+                mock.call(command, stdin=run_parameters.get("stdin", None), log_mask_re=None),
+                mock.call(command, stdin=run_parameters.get("stdin", None), log_mask_re=None),
             )
         )
         assert results == {(host, port): exec_result, (host2, port): exec_result}
@@ -502,8 +506,8 @@ def test_010_execute_together_expected(ssh, ssh2, execute_async, exec_result, ru
     )
     execute_async.assert_has_calls(
         (
-            mock.call(command, stdin=run_parameters.get("stdin", None)),
-            mock.call(command, stdin=run_parameters.get("stdin", None)),
+            mock.call(command, stdin=run_parameters.get("stdin", None), log_mask_re=None),
+            mock.call(command, stdin=run_parameters.get("stdin", None), log_mask_re=None),
         )
     )
     assert results == {(host, port): exec_result, (host2, port): exec_result}


### PR DESCRIPTION
(cherry picked from commit 31c6a013ad7b3d8fe2772be562868f1c9f976290)
(cherry picked from commit df8a43853d1c7306ccdee084136208df2b74dfac)
(cherry picked from commit f4908a594d81490a69b37dd94e47b5b214b41021)

On subprocess kill write exit code to result to prevent changes (#120)

* fix missed docstring

(cherry picked from commit fb0ef72af9b5170ad3be012bc356b4a503292488)

Add timestamp of command start to execute_async for future processing

(cherry picked from commit b3dc16231d18a4baf64586003a98caccf101e1b6)

More info in result: start timestamp (#124)

(cherry picked from commit 8b7a8e78ed7a888f6bfea7ab04c81ca7fd7ca2a3)

Always set timestamp on kill, provide spent time in str()

(cherry picked from commit 06f1650e0818b5fe8adf923a36c5999f0e4597d5)