### PR TITLE
Backport updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Pros:
 * Open Source: https://github.com/python-useful-helpers/exec-helpers
 * PyPI packaged: https://pypi.python.org/pypi/exec-helpers
 * Self-documented code: docstrings with types in comments
-* Tested: see bages on top
+* Tested: see badges on top
 * Support multiple Python versions:
 
 ::
@@ -45,7 +45,7 @@ Pros:
     Python 2.7
     PyPy
 
-.. note:: Update to version 2.0+ for usage with python 3.4+. This version is for legacy python and no new features are planned.
+.. note:: Pythons: For Python 3.4 use versions 2.x.x, python 3.5+ use versions 3.x.x, python 3.6+ use versions 4+
 
 This package includes:
 
@@ -96,7 +96,7 @@ Creation from scratch:
     )
 
 Key is a main connection key (always tried first) and keys are alternate keys.
-Key filename is afilename or list of filenames with keys, which should be loaded.
+Key filename is a filename or list of filenames with keys, which should be loaded.
 Passphrase is an alternate password for keys, if it differs from main password.
 If main key now correct for username - alternate keys tried, if correct key found - it became main.
 If no working key - password is used and None is set as main key.
@@ -217,7 +217,7 @@ Possible to call commands in parallel on multiple hosts if it's not produce huge
         remotes,  # type: typing.Iterable[SSHClient]
         command,  # type: str
         timeout=1 * 60 * 60,  # type: type: typing.Union[int, float, None]
-        expected=None,  # type: typing.Optional[typing.Iterable[int]]
+        expected=(0,),  # type: typing.Iterable[typing.Union[int, ExitCodes]]
         raise_on_err=True  # type: bool
     )
     results  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,19 +21,11 @@ environment:
       PYTHON_ARCH: "64"
 
     - PYTHON: "C:\\Python35"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.1
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
 
     - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5.x" # currently 3.5.1
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6.x" # currently 3.6.0
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_VERSION: "3.6.x" # currently 3.6.0
+      PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "64"
 
 install:

--- a/doc/source/ExecResult.rst
+++ b/doc/source/ExecResult.rst
@@ -10,7 +10,7 @@ API: ExecResult
 
     Command execution result.
 
-    .. py:method:: __init__(cmd, stdin=None, stdout=None, stderr=None, exit_code=ExitCodes.EX_INVALID)
+    .. py:method:: __init__(cmd, stdin=None, stdout=None, stderr=None, exit_code=0xDEADBEEF, *, started=None)
 
         :param cmd: command
         :type cmd: ``str``
@@ -22,6 +22,8 @@ API: ExecResult
         :type stderr: ``typing.Optional[typing.Iterable[bytes]]``
         :param exit_code: Exit code. If integer - try to convert to BASH enum.
         :type exit_code: typing.Union[int, ExitCodes]
+        :param started: Timestamp of command start
+        :type started: typing.Optional[datetime.datetime]
 
     .. py:attribute:: stdout_lock
 
@@ -41,6 +43,14 @@ API: ExecResult
 
         ``typing.Optional(datetime.datetime)``
         Timestamp
+
+    .. py:method:: set_timestamp()
+
+        Set timestamp if empty.
+
+        This will block future object changes.
+
+        .. versionadded:: 2.11.0
 
     .. py:attribute:: cmd
 
@@ -97,6 +107,13 @@ API: ExecResult
         Return(exit) code of command.
 
         :rtype: typing.Union[int, ExitCodes]
+
+    .. py:attribute:: started
+
+        ``datetime.datetime``
+        Timestamp of command start.
+
+        .. versionadded:: 2.11.0
 
     .. py:attribute:: stdout_json
 

--- a/doc/source/SSHClient.rst
+++ b/doc/source/SSHClient.rst
@@ -175,7 +175,7 @@ API: SSHClient and SSHAuth.
 
         .. versionadded:: 1.9.7
 
-    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=None, raise_on_err=True, **kwargs)
+    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=(0,), raise_on_err=True, **kwargs)
 
         Execute command and check for return code.
 
@@ -188,7 +188,7 @@ API: SSHClient and SSHAuth.
         :param error_info: Text for error details, if fail happens
         :type error_info: ``typing.Optional[str]``
         :param expected: expected return codes (0 by default)
-        :type expected: ``typing.Optional[typing.Iterable[int]]``
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :rtype: ExecResult
@@ -196,6 +196,8 @@ API: SSHClient and SSHAuth.
         :raises CalledProcessError: Unexpected exit code
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
+        .. versionchanged:: 1.10.0 Exception class can be substituted
+        .. versionchanged:: 1.11.0 Expected is not optional, defaults os dependent
 
     .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, **kwargs)
 
@@ -240,8 +242,9 @@ API: SSHClient and SSHAuth.
         :raises ExecHelperTimeoutError: Timeout exceeded
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
+        .. versionchanged:: 1.10.0 Exception class can be substituted
 
-    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=None, raise_on_err=True, **kwargs)
+    .. py:classmethod:: execute_together(remotes, command, timeout=1*60*60, expected=(0,), raise_on_err=True, **kwargs)
 
         Execute command on multiple remotes in async mode.
 
@@ -252,7 +255,7 @@ API: SSHClient and SSHAuth.
         :param timeout: Timeout for command execution.
         :type timeout: ``typing.Union[int, float, None]``
         :param expected: expected return codes (0 by default)
-        :type expected: ``typing.Optional[typing.Iterable[]]``
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :return: dictionary {(hostname, port): result}
@@ -261,6 +264,8 @@ API: SSHClient and SSHAuth.
         :raises ParallelCallExceptions: At lest one exception raised during execution (including timeout)
 
         .. versionchanged:: 1.2.0 default timeout 1 hour
+        .. versionchanged:: 1.10.0 Exception class can be substituted
+        .. versionchanged:: 1.11.0 Expected is not optional, defaults os dependent
 
     .. py:method:: open(path, mode='r')
 
@@ -425,3 +430,9 @@ API: SSHClient and SSHAuth.
     .. py:attribute:: stdout
 
         ``typing.Optional[paramiko.ChannelFile]``
+
+    .. py:attribute:: started
+
+        ``datetime.datetime``
+
+        .. versionadded:: 2.11.0

--- a/doc/source/Subprocess.rst
+++ b/doc/source/Subprocess.rst
@@ -98,7 +98,7 @@ API: Subprocess
         .. note:: stdin channel is closed after the input processing
         .. versionadded:: 1.9.7
 
-    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=None, raise_on_err=True, **kwargs)
+    .. py:method:: check_call(command, verbose=False, timeout=1*60*60, error_info=None, expected=(0,), raise_on_err=True, **kwargs)
 
         Execute command and check for return code.
 
@@ -111,7 +111,7 @@ API: Subprocess
         :param error_info: Text for error details, if fail happens
         :type error_info: ``typing.Optional[str]``
         :param expected: expected return codes (0 by default)
-        :type expected: ``typing.Optional[typing.Iterable[int]]``
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
         :param raise_on_err: Raise exception on unexpected return code
         :type raise_on_err: ``bool``
         :rtype: ExecResult
@@ -120,6 +120,8 @@ API: Subprocess
 
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0 default timeout 1 hour
+        .. versionchanged:: 1.10.0 Exception class can be substituted
+        .. versionchanged:: 1.11.0 Expected is not optional, defaults os dependent
 
     .. py:method:: check_stderr(command, verbose=False, timeout=1*60*60, error_info=None, raise_on_err=True, **kwargs)
 
@@ -143,6 +145,7 @@ API: Subprocess
 
         .. versionchanged:: 1.1.0 make method
         .. versionchanged:: 1.2.0 default timeout 1 hour
+        .. versionchanged:: 1.10.0 Exception class can be substituted
 
 
 .. py:class:: SubprocessExecuteAsyncResult
@@ -164,3 +167,9 @@ API: Subprocess
     .. py:attribute:: stdout
 
         ``typing.Optional[typing.IO]``
+
+    .. py:attribute:: started
+
+        ``datetime.datetime``
+
+        .. versionadded:: 2.11.0

--- a/doc/source/exceptions.rst
+++ b/doc/source/exceptions.rst
@@ -18,21 +18,11 @@ API: exceptions
 
     Base class for process call errors.
 
-.. py:exception:: ExecHelperTimeoutError(ExecCalledProcessError)
+class ExecHelperTimeoutProcessError(ExecCalledProcessError):
+    
+    Timeout based errors.
 
-    Execution timeout.
-
-    .. versionchanged:: 1.3.0 provide full result and timeout inside.
-    .. versionchanged:: 1.3.0 subclass ExecCalledProcessError
-
-    .. py:method:: __init__(self, result, timeout)
-
-        Exception for error on process calls.
-
-        :param result: execution result
-        :type result: exec_result.ExecResult
-        :param timeout: timeout for command
-        :type timeout: typing.Union[int, float]
+    .. versionadded:: 2.11.0
 
     .. py:attribute:: timeout
 
@@ -54,18 +44,54 @@ API: exceptions
         ``typing.Text``
         stdout string or brief string
 
+
+.. py:exception:: ExecHelperNoKillError(ExecHelperTimeoutProcessError)
+    
+    Impossible to kill process.
+
+    .. versionadded:: 2.11.0
+
+    .. py:method:: __init__(self, result, timeout)
+        
+        Exception for error on process calls.
+
+        :param result: execution result
+        :type result: ExecResult
+        :param timeout: timeout for command
+        :type timeout: typing.Union[int, float]
+
+
+.. py:exception:: ExecHelperTimeoutError(ExecHelperTimeoutProcessError)
+
+    Execution timeout.
+
+    .. versionchanged:: 1.3.0 provide full result and timeout inside.
+    .. versionchanged:: 1.3.0 subclass ExecCalledProcessError
+
+    .. py:method:: __init__(self, result, timeout)
+
+        Exception for error on process calls.
+
+        :param result: execution result
+        :type result: ExecResult
+        :param timeout: timeout for command
+        :type timeout: typing.Union[int, float]
+
+
 .. py:exception:: CalledProcessError(ExecCalledProcessError)
 
     Exception for error on process calls.
 
     .. versionchanged:: 1.1.1 - provide full result
 
-    .. py:method:: __init__(result, expected=None)
+    .. py:method:: __init__(result, expected=(0,))
 
         :param result: execution result
         :type result: ExecResult
-        :param returncode: return code
-        :type returncode: typing.Union[int, ExitCodes]
+        :param expected: expected return codes
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
+
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
     .. py:attribute:: result
 
@@ -104,7 +130,7 @@ API: exceptions
 
     Exception during parallel execution.
 
-    .. py:method:: __init__(command, errors, results, expected=None, )
+    .. py:method:: __init__(command, errors, results, expected=(0,), )
 
         :param command: command
         :type command: ``str``
@@ -113,9 +139,10 @@ API: exceptions
         :param results: all results
         :type results: typing.Dict[typing.Tuple[str, int], ExecResult]
         :param expected: expected return codes
-        :type expected: typing.Optional[typing.List[typing.List[typing.Union[int, ExitCodes]]]
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
 
         .. versionchanged:: 1.0 - fixed inheritance
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
     .. py:attribute:: cmd
 
@@ -144,7 +171,7 @@ API: exceptions
 
     Exception raised during parallel call as result of exceptions.
 
-    .. py:method:: __init__(command, exceptions, errors, results, expected=None, )
+    .. py:method:: __init__(command, exceptions, errors, results, expected=(0,), )
 
         :param command: command
         :type command: ``str``
@@ -155,9 +182,10 @@ API: exceptions
         :param results: all results
         :type results: typing.Dict[typing.Tuple[str, int], ExecResult]
         :param expected: expected return codes
-        :type expected: typing.Optional[typing.List[typing.List[typing.Union[int, ExitCodes]]]
+        :type expected: typing.Iterable[typing.Union[int, ExitCodes]]
 
         .. versionchanged:: 1.0 - fixed inheritance
+        .. versionchanged:: 2.11.0 Expected is not optional, defaults os dependent
 
     .. py:attribute:: cmd
 

--- a/exec_helpers/__init__.py
+++ b/exec_helpers/__init__.py
@@ -16,8 +16,6 @@
 
 from __future__ import absolute_import
 
-import typing
-
 import pkg_resources
 
 from .proc_enums import ExitCodes
@@ -55,7 +53,7 @@ __all__ = (
     "SubprocessExecuteAsyncResult",
     "ExitCodes",
     "ExecResult",
-)  # type: typing.Tuple[str, ...]
+)
 
 try:  # pragma: no cover
     __version__ = pkg_resources.get_distribution(__name__).version

--- a/exec_helpers/_subprocess_helpers.py
+++ b/exec_helpers/_subprocess_helpers.py
@@ -68,7 +68,7 @@ def kill_proc_tree(pid, including_parent=True):  # type:(int, bool) -> None  # p
 # Subprocess extra arguments.
 # Flags from:
 # https://stackoverflow.com/questions/13243807/popen-waiting-for-child-process-even-when-the-immediate-child-has-terminated
-subprocess_kw = {}  # type: typing.Dict[str, typing.Any]
+subprocess_kw = {}  # type: typing.Dict[typing.Text, typing.Any]
 if "Windows" == platform.system():  # pragma: no cover
     subprocess_kw["creationflags"] = 0x00000200
 else:  # pragma: no cover

--- a/exec_helpers/exceptions.py
+++ b/exec_helpers/exceptions.py
@@ -61,11 +61,8 @@ class ExecHelperTimeoutProcessError(ExecCalledProcessError):
     __slots__ = ("result", "timeout")
 
     def __init__(
-        self,
-        message,  # type: str,
-        result,  # type: exec_result.ExecResult
-        timeout  # type: typing.Union[int, float]
-    ):  # type: (...) -> None
+        self, message, result, timeout
+    ):  # type: (typing.Union[str, typing.Text], exec_result.ExecResult, typing.Union[int, float]) -> None
         """Exception for error on process calls.
 
         :param message: exception message
@@ -80,7 +77,7 @@ class ExecHelperTimeoutProcessError(ExecCalledProcessError):
         self.timeout = timeout
 
     @property
-    def cmd(self):  # type: () -> str
+    def cmd(self):  # type: () -> typing.Union[str, typing.Text]
         """Failed command."""
         return self.result.cmd
 
@@ -173,7 +170,7 @@ class CalledProcessError(ExecCalledProcessError):
         return self.result.exit_code
 
     @property
-    def cmd(self):  # type: () -> str
+    def cmd(self):  # type: () -> typing.Union[str, typing.Text]
         """Failed command."""
         return self.result.cmd
 
@@ -195,9 +192,9 @@ class ParallelCallProcessError(ExecCalledProcessError):
 
     def __init__(
         self,
-        command,  # type: str
-        errors,  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
-        results,  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
+        command,  # type: typing.Union[str, typing.Text]
+        errors,  # type: typing.Dict[typing.Tuple[typing.Union[str, typing.Text], int], exec_result.ExecResult]
+        results,  # type: typing.Dict[typing.Tuple[typing.Union[str, typing.Text], int], exec_result.ExecResult]
         expected=(proc_enums.EXPECTED,),  # type: typing.Iterable[typing.Union[int, proc_enums.ExitCodes]]
         **kwargs  # type: typing.Any
     ):  # type: (...) -> None
@@ -245,10 +242,10 @@ class ParallelCallExceptions(ParallelCallProcessError):
 
     def __init__(
         self,
-        command,  # type: str
-        exceptions,  # type: typing.Dict[typing.Tuple[str, int], Exception]
-        errors,  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
-        results,  # type: typing.Dict[typing.Tuple[str, int], exec_result.ExecResult]
+        command,  # type: typing.Union[str, typing.Text]
+        exceptions,  # type: typing.Dict[typing.Tuple[typing.Union[str, typing.Text], int], Exception]
+        errors,  # type: typing.Dict[typing.Tuple[typing.Union[str, typing.Text], int], exec_result.ExecResult]
+        results,  # type: typing.Dict[typing.Tuple[typing.Union[str, typing.Text], int], exec_result.ExecResult]
         expected=(proc_enums.EXPECTED,),  # type: typing.List[typing.Union[int, proc_enums.ExitCodes]]
         **kwargs  # type: typing.Any
     ):  # type: (...) -> None

--- a/exec_helpers/proc_enums.py
+++ b/exec_helpers/proc_enums.py
@@ -190,13 +190,13 @@ EXPECTED = 0 if "win32" == sys.platform else ExitCodes.EX_OK
 INVALID = 0xDEADBEEF if "win32" == sys.platform else ExitCodes.EX_INVALID
 
 
-def exit_code_to_enum(code):  # type: (typing.Union[int, ExitCodes]) -> typing.Union[int, ExitCodes]
+def exit_code_to_enum(code):  # type: (typing.Union[int, ExitCodes]) -> typing.Union[int, ExitCodes]  # pragma: no cover
     """Convert exit code to enum if possible."""
     if "win32" == sys.platform:
         return float(code)
     if isinstance(code, int) and code in ExitCodes.__members__.values():
         return ExitCodes(code)
-    return code  # pragma: no cover
+    return code
 
 
 def exit_codes_to_enums(

--- a/exec_helpers/ssh_auth.py
+++ b/exec_helpers/ssh_auth.py
@@ -40,12 +40,12 @@ class SSHAuth(object):
 
     def __init__(
         self,
-        username=None,  # type: typing.Optional[str]
-        password=None,  # type: typing.Optional[str]
+        username=None,  # type: typing.Optional[typing.Union[str, typing.Text]]
+        password=None,  # type: typing.Optional[typing.Union[str, typing.Text]]
         key=None,  # type: typing.Optional[paramiko.RSAKey]
         keys=None,  # type: typing.Optional[typing.Iterable[paramiko.RSAKey]]
         key_filename=None,  # type: typing.Union[typing.List[str], str, None]
-        passphrase=None,  # type: typing.Optional[str]
+        passphrase=None,  # type: typing.Optional[typing.Union[str, typing.Text]]
     ):  # type: (...) -> None
         """SSH credentials object.
 
@@ -84,7 +84,7 @@ class SSHAuth(object):
         self.__passphrase = passphrase
 
     @property
-    def username(self):  # type: () -> typing.Optional[str]
+    def username(self):  # type: () -> typing.Optional[typing.Union[str, typing.Text]]
         """Username for auth.
 
         :rtype: str
@@ -92,7 +92,7 @@ class SSHAuth(object):
         return self.__username
 
     @staticmethod
-    def __get_public_key(key):  # type: (typing.Union[paramiko.RSAKey, None]) -> typing.Optional[str]
+    def __get_public_key(key):  # type: (typing.Union[paramiko.RSAKey, None]) -> typing.Optional[typing.Text]
         """Internal method for get public key from private.
 
         :type key: paramiko.RSAKey
@@ -102,7 +102,7 @@ class SSHAuth(object):
         return "{0} {1}".format(key.get_name(), key.get_base64())
 
     @property
-    def public_key(self):  # type: () -> typing.Optional[str]
+    def public_key(self):  # type: () -> typing.Optional[typing.Text]
         """Public key for stored private key if presents else None.
 
         :rtype: str
@@ -131,7 +131,7 @@ class SSHAuth(object):
     def connect(
         self,
         client,  # type: typing.Union[paramiko.SSHClient, paramiko.Transport]
-        hostname=None,  # type: typing.Optional[str]
+        hostname=None,  # type: typing.Optional[typing.Union[str, typing.Text]]
         port=22,  # type: int
         log=True,  # type: bool
     ):  # type: (...) -> None

--- a/exec_helpers/ssh_client.py
+++ b/exec_helpers/ssh_client.py
@@ -39,11 +39,11 @@ class SSHClient(SSHClientBase):
     __slots__ = ()
 
     @staticmethod
-    def _path_esc(path):  # type: (str) -> str
+    def _path_esc(path):  # type: (typing.Union[str, typing.Text]) -> typing.Union[str, typing.Text]
         """Escape space character in the path."""
         return path.replace(" ", r"\ ")
 
-    def mkdir(self, path):  # type: (str) -> None
+    def mkdir(self, path):  # type: (typing.Union[str, typing.Text]) -> None
         """Run 'mkdir -p path' on remote.
 
         :type path: str
@@ -53,7 +53,7 @@ class SSHClient(SSHClientBase):
         # noinspection PyTypeChecker
         self.execute("mkdir -p {}\n".format(self._path_esc(path)))
 
-    def rm_rf(self, path):  # type: (str) -> None
+    def rm_rf(self, path):  # type: (typing.Union[str, typing.Text]) -> None
         """Run 'rm -rf path' on remote.
 
         :type path: str
@@ -61,7 +61,7 @@ class SSHClient(SSHClientBase):
         # noinspection PyTypeChecker
         self.execute("rm -rf {}".format(self._path_esc(path)))
 
-    def upload(self, source, target):  # type: (str, str) -> None
+    def upload(self, source, target):  # type: (typing.Union[str, typing.Text], typing.Union[str, typing.Text]) -> None
         """Upload file(s) from source to target using SFTP session.
 
         :type source: str
@@ -89,7 +89,9 @@ class SSHClient(SSHClientBase):
                     self._sftp.unlink(remote_path)
                 self._sftp.put(local_path, remote_path)
 
-    def download(self, destination, target):  # type: (str, str) -> bool
+    def download(
+        self, destination, target
+    ):  # type: (typing.Union[str, typing.Text], typing.Union[str, typing.Text]) -> bool
         """Download file(s) to target from destination.
 
         :param destination: remote path

--- a/test/test_exec_result.py
+++ b/test/test_exec_result.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 # pylint: disable=no-self-use
 
+import datetime
 import unittest
 
 import mock
@@ -58,7 +59,7 @@ class TestExecResult(unittest.TestCase):
         self.assertEqual(
             repr(result),
             "{cls}(cmd={cmd!r}, stdout={stdout}, stderr={stderr}, "
-            "exit_code={exit_code!s})".format(
+            "exit_code={exit_code!s},)".format(
                 cls=exec_helpers.ExecResult.__name__,
                 cmd=cmd,
                 stdout=(),
@@ -71,7 +72,7 @@ class TestExecResult(unittest.TestCase):
             "{cls}(\n\tcmd={cmd!r},"
             "\n\t stdout=\n'{stdout_brief}',"
             "\n\tstderr=\n'{stderr_brief}', "
-            "\n\texit_code={exit_code!s}\n)".format(
+            "\n\texit_code={exit_code!s},\n)".format(
                 cls=exec_helpers.ExecResult.__name__,
                 cmd=cmd,
                 stdout_brief="",
@@ -231,3 +232,31 @@ class TestExecResult(unittest.TestCase):
     def test_stdin_bytearray(self):
         result = exec_helpers.ExecResult(cmd, stdin=bytearray(b"STDIN"), exit_code=0)
         self.assertEqual(result.stdin, "STDIN")
+
+    def test_started(self):
+        started = datetime.datetime.utcnow()
+        result = exec_helpers.ExecResult(cmd, exit_code=0, started=started)
+        spent = (result.timestamp - started).seconds
+        self.assertIs(result.started, started)
+        self.assertEqual(
+            str(result),
+            "{cls}(\n\tcmd={cmd!r},"
+            "\n\t stdout=\n'{stdout_brief}',"
+            "\n\tstderr=\n'{stderr_brief}', "
+            "\n\texit_code={exit_code!s},"
+            "\n\tstarted={started},"
+            "\n\tspent={spent},"
+            "\n)".format(
+                cls=exec_helpers.ExecResult.__name__,
+                cmd=cmd,
+                stdout_brief="",
+                stderr_brief="",
+                exit_code=proc_enums.EXPECTED,
+                started=started.strftime("%Y-%m-%d %H:%M:%S"),
+                spent="{hours:02d}:{minutes:02d}:{seconds:02d}".format(
+                    hours=spent // (60 * 60),
+                    minutes=spent // 60,
+                    seconds=spent % 60
+                ),
+            ),
+        )

--- a/test/test_ssh_client_execute.py
+++ b/test/test_ssh_client_execute.py
@@ -17,6 +17,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import datetime
 import logging
 import typing  # noqa: F401
 
@@ -249,7 +250,7 @@ def execute_async(mocker, run_parameters):
         chan.attach_mock(status_event, "status_event")
         chan.configure_mock(exit_status=exit_code)
         return exec_helpers.SshExecuteAsyncResult(
-            interface=chan, stdin=mock.Mock, stdout=stdout_part, stderr=stderr_part
+            interface=chan, stdin=mock.Mock, stdout=stdout_part, stderr=stderr_part, started=datetime.datetime.utcnow()
         )
 
     return mocker.patch(
@@ -291,7 +292,10 @@ def test_001_execute_async(ssh, paramiko_ssh_client, ssh_transport_channel, chan
     assert isinstance(res, exec_helpers.SshExecuteAsyncResult)
     assert res.interface is ssh_transport_channel
     assert res.stdin is chan_makefile.stdin
-    assert res.stdout is chan_makefile.stdout
+    if open_stdout:
+        assert res.stdout is chan_makefile.stdout
+    else:
+        assert res.stdout is None
 
     paramiko_ssh_client.assert_has_calls(
         (


### PR DESCRIPTION
Update docs: expected is not optional

(cherry picked from commit 31c6a013ad7b3d8fe2772be562868f1c9f976290)
(cherry picked from commit df8a43853d1c7306ccdee084136208df2b74dfac)
(cherry picked from commit f4908a594d81490a69b37dd94e47b5b214b41021)

On subprocess kill write exit code to result to prevent changes (#120)

* fix missed docstring

(cherry picked from commit fb0ef72af9b5170ad3be012bc356b4a503292488)

Add timestamp of command start to execute_async for future processing

(cherry picked from commit b3dc16231d18a4baf64586003a98caccf101e1b6)

More info in result: start timestamp (#124)

(cherry picked from commit 8b7a8e78ed7a888f6bfea7ab04c81ca7fd7ca2a3)

Always set timestamp on kill, provide spent time in str()

(cherry picked from commit 06f1650e0818b5fe8adf923a36c5999f0e4597d5)
