### PR TITLE
Allow to configure chroot command

### DIFF
--- a/exec_helpers/_helpers.py
+++ b/exec_helpers/_helpers.py
@@ -78,18 +78,20 @@ def cmd_to_string(command: str | Iterable[str]) -> str:
     return shlex.join(command)
 
 
-def chroot_command(command: str, chroot_path: str | None = None) -> str:
+def chroot_command(command: str, chroot_path: str | None = None, chroot_exe: str = "chroot") -> str:
     """Prepare command for chroot execution.
 
     :param command: original command.
     :type command: str
     :param chroot_path: chroot path
     :type chroot_path: str | None
+    :param chroot_exe: chroot executable
+    :type chroot_exe: str
     :return: command to be executed with chroot rules if applicable
     :rtype: str
     """
     if chroot_path and chroot_path != "/":
         chroot_dst: str = shlex.quote(chroot_path.strip())
         quoted_command = shlex.quote(command)
-        return f'chroot {chroot_dst} sh -c {shlex.quote(f"eval {quoted_command}")}'
+        return f'{chroot_exe} {chroot_dst} sh -c {shlex.quote(f"eval {quoted_command}")}'
     return command

--- a/exec_helpers/async_api/subprocess.py
+++ b/exec_helpers/async_api/subprocess.py
@@ -355,6 +355,7 @@ class Subprocess(api.ExecHelper):
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
+        chroot_exe: str = "chroot",
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -372,6 +373,8 @@ class Subprocess(api.ExecHelper):
         :type open_stderr: bool
         :param chroot_path: chroot path override
         :type chroot_path: str | None
+        :param chroot_exe: chroot exe override
+        :type chroot_exe: str
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -389,7 +392,7 @@ class Subprocess(api.ExecHelper):
             env = dict(copy.deepcopy(os.environ) if env is None else copy.deepcopy(env))  # type: ignore[arg-type]
             env.update(env_patch)  # type: ignore[arg-type]
         return _SubprocessExecuteContext(
-            command=f"{self._prepare_command(cmd=command, chroot_path=chroot_path)}\n",
+            command=f"{self._prepare_command(cmd=command, chroot_path=chroot_path, chroot_exe=chroot_exe)}\n",
             stdin=None if stdin is None else self._string_bytes_bytearray_as_bytes(stdin),
             open_stdout=open_stdout,
             open_stderr=open_stderr,
@@ -412,6 +415,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
+        chroot_exe: str = "chroot",
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -440,6 +444,8 @@ class Subprocess(api.ExecHelper):
         :type log_stderr: bool
         :param chroot_path: chroot path override
         :type chroot_path: str | None
+        :param chroot_exe: chroot exe override
+        :type chroot_exe: str
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -468,6 +474,7 @@ class Subprocess(api.ExecHelper):
             open_stderr=open_stderr,
             log_stderr=log_stderr,
             chroot_path=chroot_path,
+            chroot_exe=chroot_exe,
             cwd=cwd,
             env=env,
             env_patch=env_patch,
@@ -487,6 +494,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
+        chroot_exe: str = "chroot",
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -515,6 +523,8 @@ class Subprocess(api.ExecHelper):
         :type log_stderr: bool
         :param chroot_path: chroot path override
         :type chroot_path: str | None
+        :param chroot_exe: chroot path override
+        :type chroot_exe: str
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -541,6 +551,7 @@ class Subprocess(api.ExecHelper):
             open_stderr=open_stderr,
             log_stderr=log_stderr,
             chroot_path=chroot_path,
+            chroot_exe=chroot_exe,
             cwd=cwd,
             env=env,
             env_patch=env_patch,

--- a/exec_helpers/subprocess.py
+++ b/exec_helpers/subprocess.py
@@ -377,6 +377,7 @@ class Subprocess(api.ExecHelper):
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
+        chroot_exe: str = "chroot",
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -394,6 +395,8 @@ class Subprocess(api.ExecHelper):
         :type open_stderr: bool
         :param chroot_path: chroot path override
         :type chroot_path: str | None
+        :param chroot_exe: chroot exe override
+        :type chroot_exe: str
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -411,7 +414,7 @@ class Subprocess(api.ExecHelper):
             env = dict(copy.deepcopy(os.environ) if env is None else copy.deepcopy(env))  # type: ignore[arg-type]
             env.update(env_patch)  # type: ignore[arg-type]
         return _SubprocessExecuteContext(
-            command=f"{self._prepare_command(cmd=command, chroot_path=chroot_path)}\n",
+            command=f"{self._prepare_command(cmd=command, chroot_path=chroot_path, chroot_exe=chroot_exe)}\n",
             stdin=None if stdin is None else self._string_bytes_bytearray_as_bytes(stdin),
             open_stdout=open_stdout,
             open_stderr=open_stderr,
@@ -434,6 +437,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
+        chroot_exe: str = "chroot",
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -462,6 +466,8 @@ class Subprocess(api.ExecHelper):
         :type log_stderr: bool
         :param chroot_path: chroot path override
         :type chroot_path: str | None
+        :param chroot_exe: chroot exe override
+        :type chroot_exe: str
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -490,6 +496,7 @@ class Subprocess(api.ExecHelper):
             open_stderr=open_stderr,
             log_stderr=log_stderr,
             chroot_path=chroot_path,
+            chroot_exe=chroot_exe,
             cwd=cwd,
             env=env,
             env_patch=env_patch,
@@ -509,6 +516,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
+        chroot_exe: str = "chroot",
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -537,6 +545,8 @@ class Subprocess(api.ExecHelper):
         :type log_stderr: bool
         :param chroot_path: chroot path override
         :type chroot_path: str | None
+        :param chroot_exe: chroot path override
+        :type chroot_exe: str
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -563,6 +573,7 @@ class Subprocess(api.ExecHelper):
             open_stderr=open_stderr,
             log_stderr=log_stderr,
             chroot_path=chroot_path,
+            chroot_exe=chroot_exe,
             cwd=cwd,
             env=env,
             env_patch=env_patch,


### PR DESCRIPTION
Allow the chroot command to be configured to something other than "chroot".

<!-- Thank you for your contribution! -->

## What do these changes do?

With this change the `chroot` command used by `exec_helpers` can be configured at runtime.

The intended use case is to make it possible to replace the default chroot command with an alternative that makes `/proc` available in the chrooted environment. Go binaries fail to execute properly otherwise.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
