### PR TITLE
Fix chroot_exe when used with context manager

### DIFF
--- a/exec_helpers/_helpers.py
+++ b/exec_helpers/_helpers.py
@@ -78,7 +78,7 @@ def cmd_to_string(command: str | Iterable[str]) -> str:
     return shlex.join(command)
 
 
-def chroot_command(command: str, chroot_path: str | None = None, chroot_exe: str = "chroot") -> str:
+def chroot_command(command: str, chroot_path: str | None = None, chroot_exe: str | None = None) -> str:
     """Prepare command for chroot execution.
 
     :param command: Original command.
@@ -86,10 +86,11 @@ def chroot_command(command: str, chroot_path: str | None = None, chroot_exe: str
     :param chroot_path: chroot path.
     :type chroot_path: str | None
     :param chroot_exe: chroot executable.
-    :type chroot_exe: str
+    :type chroot_exe: str | None
     :return: Command to be executed with chroot rules if applicable.
     :rtype: str
     """
+    chroot_exe = chroot_exe or "chroot"
     if chroot_path and chroot_path != "/":
         chroot_dst: str = shlex.quote(chroot_path.strip())
         quoted_command = shlex.quote(command)

--- a/exec_helpers/_ssh_base.py
+++ b/exec_helpers/_ssh_base.py
@@ -982,7 +982,7 @@ class SSHClientBase(api.ExecHelper):
         """
         return _KeepAliveContext(ssh=self, enforce=int(enforce))
 
-    def _prepare_command(self, cmd: str, chroot_path: str | None = None, chroot_exe: str = "chroot") -> str:
+    def _prepare_command(self, cmd: str, chroot_path: str | None = None, chroot_exe: str | None = None) -> str:
         """Prepare command: cover chroot and other cases.
 
         :param cmd: Main command.
@@ -990,6 +990,7 @@ class SSHClientBase(api.ExecHelper):
         :param chroot_exe: chroot executable, default "chroot".
         :return: The final command includes chroot, if required.
         """
+        chroot_exe = chroot_exe or "chroot"
         if not self.sudo_mode:
             return super()._prepare_command(cmd=cmd, chroot_path=chroot_path, chroot_exe=chroot_exe)
         quoted_command: str = shlex.quote(cmd)
@@ -1096,7 +1097,7 @@ class SSHClientBase(api.ExecHelper):
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         get_pty: bool = False,
         width: int = 80,
         height: int = 24,
@@ -1116,7 +1117,7 @@ class SSHClientBase(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param get_pty: Get PTY for connection.
         :type get_pty: bool
         :param width: PTY width.
@@ -1160,7 +1161,7 @@ class SSHClientBase(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         get_pty: bool = False,
         width: int = 80,
         height: int = 24,
@@ -1190,7 +1191,7 @@ class SSHClientBase(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param get_pty: Get PTY for connection.
         :type get_pty: bool
         :param width: PTY width.
@@ -1240,7 +1241,7 @@ class SSHClientBase(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         get_pty: bool = False,
         width: int = 80,
         height: int = 24,
@@ -1270,7 +1271,7 @@ class SSHClientBase(api.ExecHelper):
         :param chroot_path: Chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: Chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param get_pty: Get PTY for connection.
         :type get_pty: bool
         :param width: PTY width.
@@ -1658,7 +1659,7 @@ class SSHClientBase(api.ExecHelper):
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         verbose: bool = False,
         log_mask_re: LogMaskReT = None,
         exception_class: type[exceptions.ParallelCallProcessError] = exceptions.ParallelCallProcessError,
@@ -1685,7 +1686,7 @@ class SSHClientBase(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param verbose: Produce verbose log record on command call.
         :type verbose: bool
         :param log_mask_re: Regex lookup rule to mask command for logger.

--- a/exec_helpers/api.py
+++ b/exec_helpers/api.py
@@ -405,7 +405,9 @@ class ExecHelper(
         :rtype: str
         """
         return _helpers.chroot_command(
-            cmd, chroot_path=chroot_path or self._chroot_path, chroot_exe=chroot_exe or self._chroot_exe
+            cmd,
+            chroot_path=chroot_path or self._chroot_path,
+            chroot_exe=chroot_exe or self._chroot_exe,
         )
 
     @abc.abstractmethod

--- a/exec_helpers/api.py
+++ b/exec_helpers/api.py
@@ -173,7 +173,7 @@ class _ChRootContext(typing.ContextManager[None]):
     :param path: chroot path or None for no chroot.
     :type path: str | pathlib.Path | None
     :param chroot_exe: chroot executable.
-    :type chroot_exe: str
+    :type chroot_exe: str | None
     :raises TypeError: Incorrect type of path or chroot_exe variable.
 
     .. versionadded:: 4.1.0
@@ -181,24 +181,24 @@ class _ChRootContext(typing.ContextManager[None]):
 
     __slots__ = ("_chroot_exe_status", "_chroot_status", "_conn", "_exe", "_path")
 
-    def __init__(self, conn: ExecHelper, path: ChRootPathSetT = None, chroot_exe: str = "chroot") -> None:
+    def __init__(self, conn: ExecHelper, path: ChRootPathSetT = None, chroot_exe: str | None = None) -> None:
         """Context manager for call commands with sudo.
 
         :raises TypeError: Incorrect type of path or chroot_exe variable.
         """
         self._conn: ExecHelper = conn
         self._chroot_status: str | None = conn._chroot_path
-        self._chroot_exe_status: str = conn._chroot_exe
+        self._chroot_exe_status: str | None = conn._chroot_exe
         if path is None or isinstance(path, str):
             self._path: str | None = path
         elif isinstance(path, pathlib.Path):
             self._path = path.as_posix()  # get absolute path
         else:
             raise TypeError(f"path={path!r} is not instance of {ChRootPathSetT}")
-        if isinstance(chroot_exe, str):
-            self._exe: str = chroot_exe
+        if chroot_exe is None or isinstance(chroot_exe, str):
+            self._exe: str | None = chroot_exe
         else:
-            raise TypeError(f"chroot_exe={chroot_exe!r} is not instance of str")
+            raise TypeError(f"chroot_exe={chroot_exe!r} is not None or instance of str")
 
     def __enter__(self) -> None:
         self._conn.__enter__()
@@ -252,7 +252,7 @@ class ExecHelper(
         self.__logger: logging.Logger = logger
         self.log_mask_re: LogMaskReT = log_mask_re
         self.__chroot_path: str | None = None
-        self.__chroot_exe: str = "chroot"
+        self.__chroot_exe: str | None = None
         self.__context_count = 0
 
     @property
@@ -306,27 +306,27 @@ class ExecHelper(
         self.__chroot_path = None
 
     @property
-    def _chroot_exe(self) -> str:
+    def _chroot_exe(self) -> str | None:
         """Exe for chroot
 
-        :rtype: str
+        :rtype: str | None
         .. versionadded:: 8.1.0
         """
         return self.__chroot_exe
 
     @_chroot_exe.setter
-    def _chroot_exe(self, new_state: str) -> None:
+    def _chroot_exe(self, new_state: str | None) -> None:
         """Executable for chroot if set.
 
         :param new_state: New exe.
-        :type new_state: str
+        :type new_state: str | None
         :raises TypeError: Not supported exe information.
         .. versionadded:: 8.1.0
         """
-        if isinstance(new_state, str):
+        if new_state is None or isinstance(new_state, str):
             self.__chroot_exe = new_state
         else:
-            raise TypeError(f"chroot_exe is expected to be string, but set {new_state!r}")
+            raise TypeError(f"chroot_exe is expected to be None or string, but set {new_state!r}")
 
     @_chroot_exe.deleter
     def _chroot_exe(self) -> None:
@@ -334,15 +334,15 @@ class ExecHelper(
 
         .. versionadded:: 8.1.0
         """
-        self.__chroot_exe = "chroot"
+        self.__chroot_exe = None
 
-    def chroot(self, path: ChRootPathSetT, chroot_exe: str = "chroot") -> _ChRootContext:
+    def chroot(self, path: ChRootPathSetT, chroot_exe: str | None = None) -> _ChRootContext:
         """Context manager for changing chroot rules.
 
         :param path: chroot path or none for working without chroot.
         :type path: str | pathlib.Path | None
         :param chroot_exe: chroot exe.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :return: Context manager with selected chroot state inside.
         :rtype: typing.ContextManager
 
@@ -394,7 +394,7 @@ class ExecHelper(
 
         return _helpers.mask_command(cmd.rstrip(), self.log_mask_re, log_mask_re)
 
-    def _prepare_command(self, cmd: str, chroot_path: str | None = None, chroot_exe: str = "chroot") -> str:
+    def _prepare_command(self, cmd: str, chroot_path: str | None = None, chroot_exe: str | None = None) -> str:
         """Prepare command: cower chroot and other cases.
 
         :param cmd: Main command.
@@ -404,7 +404,9 @@ class ExecHelper(
         :return: Final command, includes chroot, if required.
         :rtype: str
         """
-        return _helpers.chroot_command(cmd, chroot_path=chroot_path or self._chroot_path, chroot_exe=chroot_exe)
+        return _helpers.chroot_command(
+            cmd, chroot_path=chroot_path or self._chroot_path, chroot_exe=chroot_exe or self._chroot_exe
+        )
 
     @abc.abstractmethod
     def _exec_command(
@@ -473,7 +475,7 @@ class ExecHelper(
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         **kwargs: typing.Any,
     ) -> ExecuteContext:
         """Get execution context manager.
@@ -489,7 +491,7 @@ class ExecHelper(
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param kwargs: Additional parameters for call.
         :type kwargs: typing.Any
 
@@ -509,7 +511,7 @@ class ExecHelper(
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         **kwargs: typing.Any,
     ) -> exec_result.ExecResult:
         """Execute command and wait for return code.
@@ -536,7 +538,7 @@ class ExecHelper(
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param kwargs: Additional parameters for call.
         :type kwargs: typing.Any
         :return: Execution result.
@@ -594,7 +596,7 @@ class ExecHelper(
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         **kwargs: typing.Any,
     ) -> exec_result.ExecResult:
         """Execute command and wait for return code.
@@ -621,7 +623,7 @@ class ExecHelper(
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param kwargs: Additional parameters for call.
         :type kwargs: typing.Any
         :return: Execution result.

--- a/exec_helpers/async_api/api.py
+++ b/exec_helpers/async_api/api.py
@@ -161,28 +161,28 @@ class _ChRootContext(typing.AsyncContextManager[None]):
     :param path: chroot path or None for no chroot.
     :type path: str | pathlib.Path | None
     :param chroot_exe: chroot executable.
-    :type chroot_exe: str
+    :type chroot_exe: str | None
     :raises TypeError: incorrect type of path or chroot_exe variable.
     """
 
-    def __init__(self, conn: ExecHelper, path: ChRootPathSetT = None, chroot_exe: str = "chroot") -> None:
+    def __init__(self, conn: ExecHelper, path: ChRootPathSetT = None, chroot_exe: str | None = None) -> None:
         """Context manager for call commands with sudo.
 
         :raises TypeError: incorrect type of path or chroot_exe variable
         """
         self._conn: ExecHelper = conn
         self._chroot_status: str | None = conn._chroot_path
-        self._chroot_exe_status: str = conn._chroot_exe
+        self._chroot_exe_status: str | None = conn._chroot_exe
         if path is None or isinstance(path, str):
             self._path: str | None = path
         elif isinstance(path, pathlib.Path):
             self._path = path.as_posix()  # get an absolute path
         else:
             raise TypeError(f"path={path!r} is not instance of {ChRootPathSetT}")
-        if isinstance(chroot_exe, str):
-            self._exe: str = chroot_exe
+        if chroot_exe is None or isinstance(chroot_exe, str):
+            self._exe: str | None = chroot_exe
         else:
-            raise TypeError(f"chroot_exe={chroot_exe!r} is not instance of str")
+            raise TypeError(f"chroot_exe={chroot_exe!r} is not None or instance of str")
 
     async def __aenter__(self) -> None:
         await self._conn.__aenter__()
@@ -224,7 +224,7 @@ class ExecHelper(
         self.__logger: logging.Logger = logger
         self.log_mask_re: LogMaskReT = log_mask_re
         self.__chroot_path: str | None = None
-        self.__chroot_exe: str = "chroot"
+        self.__chroot_exe: str | None = None
 
     @property
     def logger(self) -> logging.Logger:
@@ -269,27 +269,27 @@ class ExecHelper(
         self.__chroot_path = None
 
     @property
-    def _chroot_exe(self) -> str:
+    def _chroot_exe(self) -> str | None:
         """Exe for chroot
 
-        :rtype: str
+        :rtype: str | None
         .. versionadded:: 8.1.0
         """
         return self.__chroot_exe
 
     @_chroot_exe.setter
-    def _chroot_exe(self, new_state: str) -> None:
+    def _chroot_exe(self, new_state: str | None) -> None:
         """Executable for chroot if set.
 
         :param new_state: New exe.
-        :type new_state: str
+        :type new_state: str | None
         :raises TypeError: Not supported exe information.
         .. versionadded:: 8.1.0
         """
-        if isinstance(new_state, str):
+        if new_state is None or isinstance(new_state, str):
             self.__chroot_exe = new_state
         else:
-            raise TypeError(f"chroot_exe is expected to be string, but set {new_state!r}")
+            raise TypeError(f"chroot_exe is expected to be None or string, but set {new_state!r}")
 
     @_chroot_exe.deleter
     def _chroot_exe(self) -> None:
@@ -297,15 +297,15 @@ class ExecHelper(
 
         .. versionadded:: 8.1.0
         """
-        self.__chroot_exe = "chroot"
+        self.__chroot_exe = None
 
-    def chroot(self, path: ChRootPathSetT, chroot_exe: str = "chroot") -> _ChRootContext:
+    def chroot(self, path: ChRootPathSetT, chroot_exe: str | None = None) -> _ChRootContext:
         """Context manager for changing chroot rules.
 
         :param path: chroot path or none for working without chroot.
         :type path: str | pathlib.Path | None
-        :param chroot_exe: chroot exe.
-        :type chroot_exe: str
+        :param chroot_exe: chroot executable.
+        :type chroot_exe: str | None
         :return: Context manager with selected chroot state inside.
         :rtype: typing.ContextManager
 
@@ -351,17 +351,21 @@ class ExecHelper(
 
         return _helpers.mask_command(cmd.rstrip(), self.log_mask_re, log_mask_re)
 
-    def _prepare_command(self, cmd: str, chroot_path: str | None = None, chroot_exe: str = "chroot") -> str:
+    def _prepare_command(self, cmd: str, chroot_path: str | None = None, chroot_exe: str | None = None) -> str:
         """Prepare command: cower chroot and other cases.
 
         :param cmd: Main command.
         :type cmd: str
         :param chroot_path: Path to make chroot for execution.
         :type chroot_path: str | None
+        :param chroot_exe: chroot exe override
+        :type chroot_exe: str | None
         :return: Final command, includes chroot, if required.
         :rtype: str
         """
-        return _helpers.chroot_command(cmd, chroot_path=chroot_path or self._chroot_path, chroot_exe=chroot_exe)
+        return _helpers.chroot_command(
+            cmd, chroot_path=chroot_path or self._chroot_path, chroot_exe=chroot_exe or self._chroot_exe
+        )
 
     @abc.abstractmethod
     async def _exec_command(
@@ -428,7 +432,7 @@ class ExecHelper(
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         **kwargs: typing.Any,
     ) -> ExecuteContext:
         """Get execution context manager.
@@ -444,7 +448,7 @@ class ExecHelper(
         :param chroot_path: Chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: Chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param kwargs: Additional parameters for call.
         :type kwargs: typing.Any
         .. versionadded:: 8.0.0
@@ -463,7 +467,7 @@ class ExecHelper(
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         **kwargs: typing.Any,
     ) -> exec_result.ExecResult:
         """Execute command and wait for return code.
@@ -490,7 +494,7 @@ class ExecHelper(
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param kwargs: Additional parameters for call.
         :type kwargs: typing.Any
         :return: Execution result.
@@ -546,7 +550,7 @@ class ExecHelper(
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         **kwargs: typing.Any,
     ) -> exec_result.ExecResult:
         """Execute command and wait for return code.
@@ -573,7 +577,7 @@ class ExecHelper(
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param kwargs: Additional parameters for call.
         :type kwargs: typing.Any
         :return: Execution result.

--- a/exec_helpers/async_api/api.py
+++ b/exec_helpers/async_api/api.py
@@ -364,7 +364,9 @@ class ExecHelper(
         :rtype: str
         """
         return _helpers.chroot_command(
-            cmd, chroot_path=chroot_path or self._chroot_path, chroot_exe=chroot_exe or self._chroot_exe
+            cmd,
+            chroot_path=chroot_path or self._chroot_path,
+            chroot_exe=chroot_exe or self._chroot_exe,
         )
 
     @abc.abstractmethod

--- a/exec_helpers/async_api/subprocess.py
+++ b/exec_helpers/async_api/subprocess.py
@@ -355,7 +355,7 @@ class Subprocess(api.ExecHelper):
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -374,7 +374,7 @@ class Subprocess(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -415,7 +415,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -445,7 +445,7 @@ class Subprocess(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -494,7 +494,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -523,8 +523,8 @@ class Subprocess(api.ExecHelper):
         :type log_stderr: bool
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
-        :param chroot_exe: chroot path override.
-        :type chroot_exe: str
+        :param chroot_exe: chroot exe override.
+        :type chroot_exe: str | None
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.

--- a/exec_helpers/subprocess.py
+++ b/exec_helpers/subprocess.py
@@ -377,7 +377,7 @@ class Subprocess(api.ExecHelper):
         open_stdout: bool = True,
         open_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -396,7 +396,7 @@ class Subprocess(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -437,7 +437,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -467,7 +467,7 @@ class Subprocess(api.ExecHelper):
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
         :param chroot_exe: chroot exe override.
-        :type chroot_exe: str
+        :type chroot_exe: str | None
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.
@@ -516,7 +516,7 @@ class Subprocess(api.ExecHelper):
         open_stderr: bool = True,
         log_stderr: bool = True,
         chroot_path: str | None = None,
-        chroot_exe: str = "chroot",
+        chroot_exe: str | None = None,
         cwd: CwdT = None,
         env: EnvT = None,
         env_patch: EnvT = None,
@@ -545,8 +545,8 @@ class Subprocess(api.ExecHelper):
         :type log_stderr: bool
         :param chroot_path: chroot path override.
         :type chroot_path: str | None
-        :param chroot_exe: chroot path override.
-        :type chroot_exe: str
+        :param chroot_exe: chroot exe override.
+        :type chroot_exe: str | None
         :param cwd: Sets the current directory before the child is executed.
         :type cwd: str | bytes | pathlib.Path | None
         :param env: Defines the environment variables for the new process.


### PR DESCRIPTION
Use None for `chroot_exe` default argument.  This allows us to use similar logic as `chroot_path`.

<!-- Thank you for your contribution! -->

## What do these changes do?

This makes overriding chroot executable in a context manager work as expected.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
